### PR TITLE
Include relative

### DIFF
--- a/lib/truffle-hog.rb
+++ b/lib/truffle-hog.rb
@@ -1,9 +1,9 @@
 module TruffleHog
   VERSION = "0.0.3"
   
-  def self.parse_feed_urls(html, favor = :all)
-    rss_links  = scan_for_tag(html, "rss")
-    atom_links = scan_for_tag(html, "atom")
+  def self.parse_feed_urls(html, favor = :all, opts = {})
+    rss_links  = scan_for_tag(html, "rss", opts[:include_relative])
+    atom_links = scan_for_tag(html, "atom", opts[:include_relative])
 
     case favor
     when :all
@@ -15,11 +15,11 @@ module TruffleHog
     end
   end
   
-  def self.scan_for_tag(html, type)
-    urls(html, "link", type) + urls(html, "a", type)
+  def self.scan_for_tag(html, type, include_relative = false)
+    urls(html, "link", type, include_relative) + urls(html, "a", type, include_relative)
   end
   
-  def self.urls(html, tag, type)
+  def self.urls(html, tag, type, include_relative = false)
     tags = html.scan(/(<#{tag}.*?>)/).flatten
     feed_tags = collect(tags, type)
     feed_tags.map do |tag|
@@ -29,7 +29,11 @@ module TruffleHog
       else
         url = matches[1]
       end
-      url =~ /^http.*/ ? url : nil
+      if include_relative
+        url
+      else
+        url =~ /^http.*/ ? url : nil
+      end
     end.compact
   end
   

--- a/spec/relative.html
+++ b/spec/relative.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" id="sixapart-standard">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<meta name="generator" content="http://www.typepad.com/" />
+	
+	<meta name="description" content="Entrepreneurship, programming, software development, politics, NYC, and random thoughts." />
+	<link rel="stylesheet" href="http://www.pauldix.net/styles.css?v=2" type="text/css" media="screen" />
+	<link rel="stylesheet" href="/.shared/themes/common/print.css" type="text/css" media="print" />
+	<link rel="alternate" type="application/atom+xml" title="Posts on 'Paul Dix Explains Nothing' (Atom)" href="/in_head/atom.xml" />
+	<link rel="alternate" type="application/rss+xml" title="Posts on 'Paul Dix Explains Nothing' (RSS 1.0)" href="/in_head/index.rdf" />
+
+	<link rel="alternate" type="application/rss+xml" title="Posts on 'Paul Dix Explains Nothing' (RSS 2.0)" href="/in_head/rss.xml" />
+
+	<title>Paul Dix Explains Nothing</title>
+	<link rel="openid.server" href="http://www.typepad.com/services/openid/server" />
+	<link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://www.typepad.com/services/rsd/6a00d8341f4a0d53ef00d8341f536453ef" />
+			<link rel="meta" type="application/rdf+xml" title="FOAF" href="http://pauldix.blogs.com/foaf.rdf" />
+	
+        
+</head>
+
+<body class="layout-two-column-right">
+	
+	<div id="container">
+
+		<div id="container-inner" class="pkg">
+			
+			<!-- banner -->
+<div id="banner">
+	<div id="banner-inner" class="pkg">
+		
+		<h1 id="banner-header"><a href="http://www.pauldix.net/" accesskey="1">Paul Dix Explains Nothing</a></h1>
+		<h2 id="banner-description">Entrepreneurship, programming, software development, politics, NYC, and random thoughts.</h2>
+	</div>
+</div>
+
+
+			<div id="pagebody">
+				<div id="pagebody-inner" class="pkg">
+					<div id="alpha">
+						<div id="alpha-inner" class="pkg">
+							<!-- entry list sticky -->
+
+			<h2 class="date-header">October 08, 2009</h2>
+	
+	<div class="entry-author-paul_dix entry-type-post entry" id="entry-6a00d8341f4a0d53ef0120a6247d0c970c">
+
+					<h3 class="entry-header"><a href="http://www.pauldix.net/2009/10/using-the-nginx-memcached-module-with-passenger.html">Using the Nginx Memcached module with Passenger</a></h3>
+		
+		<div class="entry-content">
+			<div class="entry-body">
+				<p>Nginx, everyone&#39;s favorite speedy web server has a module to hook in directly to memcached. For those of us running Ruby servers behind nginx we can avoid hitting our running Ruby processes completely on a cache hit. I&#39;ll avoid the details and point you instead to <a href="http://www.igvita.com/2008/02/11/nginx-and-memcached-a-400-boost/">Ilya Grigorik&#39;s coverage of the Nginx + Memcached</a> goodness.</p>
+
+<p>My trouble was that I couldn&#39;t find a good example of using Passenger and the Nginx memcached module together. The <a href="http://wiki.nginx.org/NginxHttpMemcachedModule">module documentation</a> shows how to proxy cache misses to your running web servers (like Mongrel), but with Passenger you don&#39;t know what processes are running. This is because Passenger automatically spawns web server processes for you. Well, after a little trial and error I figured out a config that works.</p>
+
+<p>I&#39;ll show the config at the bottom of this post, but first let&#39;s look at some performance numbers. For my use case this goes beyond simple page caching. I&#39;m using HTTP services to serve up data. So it&#39;s entirely possible that I can achieve a high cache hit ratio and make things really speedy. To check performance I set up two tests. The first returns a small json object and the second returns a collection of objects. The test Passenger application is a simple Sinatra service that looks like this:</p>
+
+<pre>require &#39;rubygems&#39;<br />require &#39;json&#39;<br />require &#39;sinatra&#39;<br /><br />get &#39;/api/v1/comments/users/:id/no_cache&#39; do<br /> ([{:id =&gt; 2, <br />   :user_id =&gt; &quot;paul&quot;, <br />   :body =&gt; &quot;this is a test comment to see how this thing works.&quot;}<br />  ] * 25).to_json<br />end<br /><br />get &#39;/api/v1/comments/:id/no_cache&#39; do<br /> {:id =&gt; 2, <br />  :user_id =&gt; &quot;paul&quot;, <br />  :body =&gt; &quot;this is a test comment to see how this thing works.&quot;}.to_json<br />end</pre>
+
+<p>The setup was a single small EC2 instance running nginx and another small instance in the same availability zone running Apache Bench against the server. The first run is for cache misses that fall through to Passenger. The second run is against cache hits that go from nginx straight to memcached. Here&#39;s a small section of the results:</p>
+
+<pre># single json object cache miss (passenger)<br />ab -n 10000 -c 50 http://ec2-some-ip.compute-1.amazonaws.com/api/v1/comments/1/no_cache<br />Requests per second: 310.08 [#/sec] (mean)<br />Time per request: 161.249 [ms] (mean)<br />Time per request: 3.225 [ms] (mean, across all concurrent requests)<br />Transfer rate: 94.17 [Kbytes/sec] received<br /><br /># single json object cache hit (nginx + memcached)<br />ab -n 10000 -c 50 http://ec2-some-ip.compute-1.amazonaws.com/api/v1/comments/1<br />Requests per second: 2496.64 [#/sec] (mean)<br />Time per request: 20.027 [ms] (mean)<br />Time per request: 0.401 [ms] (mean, across all concurrent requests)<br />Transfer rate: 556.12 [Kbytes/sec] received<br /><br /># collection of 25 json objects cache miss (passenger)<br />ab -n 10000 -c 50 http://ec2-some-ip.compute-1.amazonaws.com/api/v1/comments/users/1/no_cache<br />Requests per second: 225.98 [#/sec] (mean)<br />Time per request: 221.256 [ms] (mean)<br />Time per request: 4.425 [ms] (mean, across all concurrent requests)<br />Transfer rate: 530.31 [Kbytes/sec] received<br /><br /># collection of 25 json objects cache hit (nginx + memcached)<br />Requests per second: 2385.22 [#/sec] (mean)<br />Time per request: 20.962 [ms] (mean)<br />Time per request: 0.419 [ms] (mean, across all concurrent requests)<br />Transfer rate: 5434.29 [Kbytes/sec] received<br /></pre>
+
+<p>As you can see the time per request and the number of concurrent requests is significantly higher for the cache hits. The performance bump this reflects is actually better than the 400% Ilya mentioned in his blog post (of course, your mileage may vary). If you&#39;re interested, I&#39;ve posted the <a href="http://gist.github.com/205103">full ab output in this gist</a>.</p>
+
+<p>And finally, without any more delay, here&#39;s the nginx.conf I used.</p>
+<pre>user nobody nogroup;<br />worker_processes 4;<br /><br />error_log logs/error.log;<br /><br />events {<br /> worker_connections 1024;<br />}<br /><br />http {<br /> passenger_root /usr/lib/ruby/gems/1.8/gems/passenger-2.2.5;<br /> passenger_ruby /usr/bin/ruby1.8;<br /><br /> include mime.types;<br /> default_type application/octet-stream;<br /> tcp_nopush on;<br /> tcp_nodelay on;<br /> gzip on;<br /><br /> sendfile on;<br /><br /> keepalive_timeout 65;<br /><br /> server {<br /> listen 80;<br /> server_name localhost; # put in your IP in place of localhost<br /> location / {<br /> set $memcached_key $uri;<br /> memcached_pass 127.0.0.1:11211;<br /> default_type application/json;<br /> error_page 404 502 = @fallback;<br /> }<br /><br /> location @fallback {<br /> root /var/www/public;<br /> passenger_enabled on;<br /> }<br /> }<br />}<br /></pre>
+
+			</div>
+			
+							<script src="http://feeds.feedburner.com/~s/PaulDixExplainsNothing?i=http%3A%2F%2Fwww.pauldix.net%2F2009%2F10%2Fusing-the-nginx-memcached-module-with-passenger.html" type="text/javascript"></script>
+			
+		</div>
+		<div class="entry-footer">
+			<p class="entry-footer-info">
+				<span class="post-footers">October 08, 2009 at 11:28 AM </span> <span class="separator">|</span> <a class="permalink" href="http://www.pauldix.net/2009/10/using-the-nginx-memcached-module-with-passenger.html">Permalink</a>
+
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/10/using-the-nginx-memcached-module-with-passenger.html#comments">Comments (0)</a>
+				
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/10/using-the-nginx-memcached-module-with-passenger.html#trackback">TrackBack (0)</a>
+				
+			</p>
+			<!-- technorati tags -->
+	
+
+
+			<!-- post footer links -->
+
+		</div>
+	</div>
+	
+			<h2 class="date-header">September 10, 2009</h2>
+	
+	<div class="entry-author-paul_dix entry-type-post entry" id="entry-6a00d8341f4a0d53ef0120a560db6e970b">
+					<h3 class="entry-header"><a href="http://www.pauldix.net/2009/09/first-nyc-machine-learning-meetup.html">First NYC Machine Learning Meetup</a></h3>
+		
+		<div class="entry-content">
+			<div class="entry-body">
+
+				<p>I have organized the first NYC Machine Learning meetup. The goal of the group is to have discussions based on recent papers in the machine learning community. This can include topics like search, information retrieval, pattern recognition, natural language processing, artificial intelligence, collaborative filtering, recommendation systems, and other topics related to machine learning.</p><p>The format is pretty simple. Pick a research paper. Everyone in the group reads and attempts to understand the paper before the meetup. Meet and discuss with one person leading the discussion. For the first meeting we&#39;ll be going over Yehuda Koren&#39;s paper &quot;<a href="http://research.yahoo.com/files/kdd-fp074-koren.pdf">Collaborative Filtering with Temporal Dynamics</a>.&quot; This paper is based on his work in the BellKor Pragmatic Chaos team that is in contention for the Netflix prize.</p><p>To RSVP go to the <a href="http://www.meetup.com/NYC-Machine-Learning/calendar/11331674/">NYC Machine Learning meetup page</a>. You don&#39;t need to be a machine learning expert to join in the conversation. Just make an honest attempt to read the paper and we can go over questions.</p>
+			</div>
+			
+							<script src="http://feeds.feedburner.com/~s/PaulDixExplainsNothing?i=http%3A%2F%2Fwww.pauldix.net%2F2009%2F09%2Ffirst-nyc-machine-learning-meetup.html" type="text/javascript"></script>
+
+			
+		</div>
+		<div class="entry-footer">
+			<p class="entry-footer-info">
+				<span class="post-footers">September 10, 2009 at 11:22 AM </span> <span class="separator">|</span> <a class="permalink" href="http://www.pauldix.net/2009/09/first-nyc-machine-learning-meetup.html">Permalink</a>
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/09/first-nyc-machine-learning-meetup.html#comments">Comments (0)</a>
+
+				
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/09/first-nyc-machine-learning-meetup.html#trackback">TrackBack (0)</a>
+				
+			</p>
+			<!-- technorati tags -->
+	
+
+
+			<!-- post footer links -->
+
+		</div>
+	</div>
+
+	
+			<h2 class="date-header">July 08, 2009</h2>
+	
+	<div class="entry-author-paul_dix entry-type-post entry" id="entry-6a00d8341f4a0d53ef011571daa51b970b">
+					<h3 class="entry-header"><a href="http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html">Using Named Pipes in Ruby for Inter-process Communication</a></h3>
+		
+		<div class="entry-content">
+			<div class="entry-body">
+				<p>Named pipes are an old trick for Unix types to accomplish communication between processes. I&#39;ve actually never used the trick and it took me a little time to figure out how to do this in ruby. In this post I present a quick example for your enjoyment.</p><p>First, in a terminal window create the named pipe:</p>
+
+<pre>mkfifo my_pipe<br /></pre><p>
+At that point it looks like a file on the file system. It even has permissions on it. Now in Ruby processes we can open it like a file:
+</p><pre>output = open(&quot;my_pipe&quot;, &quot;w+&quot;) # the w+ means we don&#39;t block<br />output.puts &quot;hello world&quot;<br />output.flush # do this when we&#39;re done writing data<br /></pre><p>
+And here we are in a completely separate process:
+</p><pre>input = open(&quot;my_pipe&quot;, &quot;r+&quot;) # the r+ means we don&#39;t block<br />puts input.gets # will block if there&#39;s nothing in the pipe<br /></pre><p>
+
+If you pair that up with JSON, you&#39;ve got a quick and efficient way to do inter-process communication. I&#39;m actually using this trick so I can have my Sinatra web service call out to C++, Java, and Python processes.</p>
+			</div>
+			
+							<script src="http://feeds.feedburner.com/~s/PaulDixExplainsNothing?i=http%3A%2F%2Fwww.pauldix.net%2F2009%2F07%2Fusing-named-pipes-in-ruby-for-interprocess-communication.html" type="text/javascript"></script>
+			
+		</div>
+		<div class="entry-footer">
+			<p class="entry-footer-info">
+				<span class="post-footers">July 08, 2009 at 12:09 PM </span> <span class="separator">|</span> <a class="permalink" href="http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html">Permalink</a>
+
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html#comments">Comments (0)</a>
+				
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html#trackback">TrackBack (0)</a>
+				
+			</p>
+			<!-- technorati tags -->
+	
+
+
+			<!-- post footer links -->
+
+		</div>
+	</div>
+	
+			<h2 class="date-header">June 05, 2009</h2>
+	
+	<div class="entry-author-paul_dix entry-type-post entry" id="entry-67675255">
+					<h3 class="entry-header"><a href="http://www.pauldix.net/2009/06/on-ruby-interview-with-me.html">On Ruby Interview with me</a></h3>
+		
+		<div class="entry-content">
+			<div class="entry-body">
+
+				<p>Pat Eyler of On Ruby has posted <a href="http://on-ruby.blogspot.com/2009/06/feedzirra-and-typhoeus-interview-with.html">an interview with me about Typhoeus, Feedzirra, and software development in general</a>.</p>
+			</div>
+			
+							<script src="http://feeds.feedburner.com/~s/PaulDixExplainsNothing?i=http%3A%2F%2Fwww.pauldix.net%2F2009%2F06%2Fon-ruby-interview-with-me.html" type="text/javascript"></script>
+			
+		</div>
+		<div class="entry-footer">
+			<p class="entry-footer-info">
+				<span class="post-footers">June 05, 2009 at 10:21 AM </span> <span class="separator">|</span> <a class="permalink" href="http://www.pauldix.net/2009/06/on-ruby-interview-with-me.html">Permalink</a>
+
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/06/on-ruby-interview-with-me.html#comments">Comments (0)</a>
+				
+				
+			</p>
+			<!-- technorati tags -->
+	
+
+
+			<!-- post footer links -->
+
+		</div>
+	</div>
+
+	
+			<h2 class="date-header">May 07, 2009</h2>
+	
+	<div class="entry-category-ruby entry-author-paul_dix entry-type-post entry" id="entry-66518947">
+					<h3 class="entry-header"><a href="http://www.pauldix.net/2009/05/breath-fire-over-http-in-ruby-with-typhoeus.html">Breathe fire over HTTP in Ruby with Typhoeus</a></h3>
+		
+		<div class="entry-content">
+			<div class="entry-body">
+				<p>Typhoeus is a mythical greek god with 100 fire breathing serpent heads. He&#39;s also the father of the more well known Hydra. Like the fearsome beast, <a href="http://github.com/pauldix/typhoeus/tree/master">Typhoeus is a fearsome Ruby library that enables parallel HTTP requests while cleanly encapsulating handling logic</a>. Specifically, it uses libcurl and libcurl-multi to run HTTP really fast. Further, it&#39;s designed with the focus of creating client libraries that work with web services. These could be external services like Twitter or systems like CouchDB and SimpleDB or custom web services that you write yourself.
+
+
+</p><p>The libcurl interface is contained within the library. Rather than trying to get Curb to do what I wanted, I decided to start with a clean slate and write the c bindings myself. Other than the libcurl interface, it has a nice DSL for creating classes and client libraries for web services.
+</p><p>The inspiration for the library came from an <a href="http://queue.acm.org/detail.cfm?id=1142065">interview with Amazon CTO Werner Vogels</a>. In the interview he states that when a user visits the Amazon.com home page it calls out to up to 100 different services to construct the single page before returning it to the user. I like Amazon&#39;s approach of a services architecture, specially AWS, and wondered if I could do the same thing in Ruby. Typhoeus is the result of that effort.
+
+</p><p>I set up a benchmark to test how the parallel performance works vs Ruby&#39;s built in NET::HTTP. The setup was a local evented HTTP server that would take a request, sleep for 500 milliseconds and then issued a blank response. I set up the client to call this 20 times. Here are the results:
+
+</p><pre> net::http 0.030000 0.010000 0.040000 ( 10.054327)<br /> typhoeus 0.020000 0.070000 0.090000 ( 0.508817)<br /></pre><p>
+
+We can see from this that NET::HTTP performs as expected, taking 10 seconds to run 20 500ms requests. Typhoeus only takes 500ms (the time of the response that took the longest.)
+</p><p>Hopefully I&#39;ve whetted your appetite. Before I get to the code examples and the API, I&#39;d like to put in a plug for my employer <a href="http://kgb.com">kgb</a>. They were nice enough to let me release this library as open source. We&#39;re also hiring for good front end rails developers, designers, and anyone with experience in search, information retrieval, and machine learning. Please drop me a line if you dominate code and if you&#39;re interested in joining an awesome team.
+
+</p><p>Finally, on the the codez. Here are some usage examples and notes from the readme (<a href="http://gist.github.com/108444">gist for easier reading</a>).
+</p><pre># here&#39;s an example for twitter search<br /># Including Typhoeus adds http methods like get, put, post, and delete.<br /># What&#39;s more interesting though is the stuff to build up what I call<br /># remote_methods.<br />class Twitter<br /> include Typhoeus<br /> remote_defaults :on_success =&gt; lambda {|response| JSON.parse(response.body)},<br /> :on_failure =&gt; lambda {|response| puts &quot;error code: #{response.code}&quot;},<br /> :base_uri =&gt; &quot;http://search.twitter.com&quot;<br /><br /> define_remote_method :search, :path =&gt; &#39;/search.json&#39;<br /> define_remote_method :trends, :path =&gt; &#39;/trends/:time_frame.json&#39;<br />end<br /><br />tweets = Twitter.search(:params =&gt; {:q =&gt; &quot;railsconf&quot;})<br /><br /># if you look at the path argument for the :trends method, it has :time_frame.<br /># this tells it to add in a parameter called :time_frame that gets interpolated<br /># and inserted.<br />trends = Twitter.trends(:time_frame =&gt; :current)<br /><br /># and then the calls don&#39;t actually happen until the first time you<br /># call a method on one of the objects returned from the remote_method<br />puts tweets.keys # it&#39;s a hash from parsed JSON<br /><br /># you can also do things like override any of the default parameters<br />Twitter.search(:params =&gt; {:q =&gt; &quot;hi&quot;}, :on_success =&gt; lambda {|response| puts response.body})<br /><br /># on_success and on_failure lambdas take a response object. <br /># It has four accesssors: code, body, headers, and time<br /><br /># here&#39;s and example of memoization<br />twitter_searches = []<br />10.times do<br /> twitter_searches &lt;&lt; Twitter.search(:params =&gt; {:q =&gt; &quot;railsconf&quot;})<br />end<br /><br /># this next part will actually make the call. However, it only makes one<br /># http request and parses the response once. The rest are memoized.<br />twitter_searches.each {|s| puts s.keys}<br /><br /># you can also have it cache responses and do gets automatically<br /># here we define a remote method that caches the responses for 60 seconds<br />klass = Class.new do<br /> include Typhoeus<br /> <br /> define_remote_method :foo, :base_uri =&gt; &quot;http://localhost:3001&quot;, :cache_responses =&gt; 60<br />end<br /><br />klass.cache = some_memcached_instance_or_whatever<br />response = klass.foo <br />puts response.body # makes the request<br /><br />second_response = klass.foo<br />puts response.body # pulls from the cache without making a request<br /><br /># you can also pass timeouts on the define_remote_method or as a parameter<br /># Note that timeouts are in milliseconds.<br />Twitter.trends(:time_frame =&gt; :current, :timeout =&gt; 2000)<br /><br /># you also get the normal get, put, post, and delete methods<br />class Remote<br /> include Typhoeus<br />end<br /><br />Remote.get(&quot;http://www.pauldix.net&quot;)<br />Remote.put(&quot;http://&quot;, :body =&gt; &quot;this is a request body&quot;)<br />Remote.post(&quot;http://localhost:3001/posts.xml&quot;, <br /> {:params =&gt; {:post =&gt; {:author =&gt; &quot;paul&quot;, :title =&gt; &quot;a title&quot;, :body =&gt; &quot;a body&quot;}}})<br />Remote.delete(&quot;http://localhost:3001/posts/1&quot;)<br /><br /></pre><p><strong>Important Update:</strong>I should have mentioned that some bits of C were pulled from <a href="http://www.idle-hacking.com/2008/07/updated-curb-multi-interface-patch/">Todd Fisher&#39;s update to curb for the multi interface</a>. The easy code is completely different and some of the C stuff in Multi has changed. However, a good chunk of the multi code comes straight from there. Thanks Todd. Sorry for not mentioning it earlier.</p>
+
+			</div>
+			
+							<script src="http://feeds.feedburner.com/~s/PaulDixExplainsNothing?i=http%3A%2F%2Fwww.pauldix.net%2F2009%2F05%2Fbreath-fire-over-http-in-ruby-with-typhoeus.html" type="text/javascript"></script>
+			
+		</div>
+		<div class="entry-footer">
+			<p class="entry-footer-info">
+				<span class="post-footers">May 07, 2009 at 06:52 PM in <a href="http://www.pauldix.net/ruby/">Ruby</a> </span> <span class="separator">|</span> <a class="permalink" href="http://www.pauldix.net/2009/05/breath-fire-over-http-in-ruby-with-typhoeus.html">Permalink</a>
+
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/05/breath-fire-over-http-in-ruby-with-typhoeus.html#comments">Comments (18)</a>
+				
+				
+			</p>
+			<!-- technorati tags -->
+	
+
+
+			<!-- post footer links -->
+
+		</div>
+	</div>
+
+			<div class="pager-bottom pager-entries pager content-nav">
+		<div class="pager-inner">
+			
+			
+			<span class="pager-right">
+				<a href="http://www.pauldix.net/page/2/"><span class="pager-label"></span>
+					<span class="chevron">&#187;</span></a>
+			</span>
+		</div>
+	</div>
+	
+	
+
+
+						</div>
+
+					</div>
+					<div id="beta">
+						<div id="beta-inner" class="pkg">
+							<!-- sidebar -->
+
+
+<!-- user photo -->
+	<div class="module-photo module">
+		<div class="module-content"><img src="http://pauldix.blogs.com/.a/6a00d8341f4a0d53ef00e553f5dd328833-150wi" alt="My Photo" /></div>
+	</div>
+
+<div class="module-widget module" id="widget-LinkedIn_linkedin_profile_widget">
+	<div class="module-content">
+    	            <div style="text-align:center"><a href="http://www.linkedin.com/in/pauldix?trk=btn_typepad" ><img src="http://www.linkedin.com/img/webpromo/btn_viewmy_160x25.gif" width="160" height="25" border="0" alt="View Paul Dix's profile on LinkedIn" style="margin-bottom:5px"></a><br><a href="http://www.linkedin.com/in/pauldix?trk=btn_typepad" style="color:#0783B6;font:11px arial,sans-serif;text-decoration:none">See how we're connected</a></div>
+          
+	</div>
+</div><div class="module-email module">
+	<div class="module-content">
+		<script type="text/javascript">
+<!--
+document.write('<a href="ma' + 'ilto:&#112;&#97;&#117;&#108;&#64;&#112;&#97;&#117;&#108;&#100;&#105;&#120;&#46;&#110;&#101;&#116;">Email Me</a>');
+// -->
+</script>
+
+	</div>
+
+</div>
+<div class="module-widget module" id="widget-FeedBurner_standardSmall">
+	<div class="module-content">
+    	<p><a href="http://feeds.feedburner.com/PaulDixExplainsNothing" rel="alternate" type="application/rss+xml"><img src="http://www.feedburner.com/fb/images/pub/feed-icon16x16.png" alt="" style="vertical-align:middle;border:0"/></a>&nbsp;<a href="http://feeds.feedburner.com/PaulDixExplainsNothing/in_body/rss" rel="alternate" type="application/rss+xml">Subscribe in a reader</a> <a href="http://feeds.feedburner.com/PaulDixExplainsNothing/in_body/atom" rel="alternate" type="application/atom+xml">Subscribe in a reader</a></p>
+	</div>
+</div><div class="module-typelist module">
+	<h2 class="module-header">Linkage</h2>
+	<div class="module-content">
+		<ul class="module-list">
+
+							<li class="module-list-item"><a href="http://github.com/pauldix">My Github</a><br /></li>
+							<li class="module-list-item"><a href="http://github.com/pauldix/feedzirra">Feedzirra</a><br />My Ruby library for parsing and fetching feeds at blinding speed.</li>
+							<li class="module-list-item"><a href="http://github.com/pauldix/sax-machine">SAX Machine</a><br />My Ruby library exposes a DSL for building Nokogiri backed SAX parsers.</li>
+							<li class="module-list-item"><a href="http://github.com/pauldix/typhoeus">Typhoeus</a><br />My Ruby library for running HTTP requests quickly, easily, and in parallel.</li>
+			
+		</ul>
+
+	</div>
+</div>
+
+	<div class="module-archives module">
+		<h2 class="module-header">Recent Posts</h2>
+		<div class="module-content">
+			<ul class="module-list">
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/10/using-the-nginx-memcached-module-with-passenger.html">Using the Nginx Memcached module with Passenger</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/09/first-nyc-machine-learning-meetup.html">First NYC Machine Learning Meetup</a></li>
+
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html">Using Named Pipes in Ruby for Inter-process Communication</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/06/on-ruby-interview-with-me.html">On Ruby Interview with me</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/05/breath-fire-over-http-in-ruby-with-typhoeus.html">Breathe fire over HTTP in Ruby with Typhoeus</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/05/railsconf-this-week.html">RailsConf this week</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/04/small-feedzirra-release.html">Small Feedzirra Release</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/04/notes-from-my-machine-learning-and-the-semantic-web-presentation.html">Notes from my Machine Learning and the Semantic Web Presentation</a></li>
+
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/04/a-passenger-rackup-file-for-sinatra.html">A Passenger Rackup File for Sinatra</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/03/feedzirra-release-adds-simple-custom-parsing-and-more.html">Feedzirra release adds simple custom parsing and more!</a></li>
+					
+				
+			</ul>
+		</div>
+	</div>
+<div class="module-feed module">
+	<h2 class="module-header">Twitter / pauldix</h2>
+	<div class="module-content" id="feed-39393fef12adc57def656d605a14747caac52903">
+
+		<script type="text/javascript" defer="defer" src="http://pauldix.blogs.com/.services/content?src=Feed:http%3A%2F%2Ftwitter.com%2Fstatuses%2Fuser_timeline%2F13826102.rss,5"></script>
+	</div>
+</div>
+<div class="module-elsewhere module">
+	<h2 class="module-header">Services I'm On</h2>
+			<div class="typelist-plain module-content">
+			<ul class="module-list">
+									<li class="module-list-item">
+						<a href="aim:goim?screenname=dixp77"><img src="/.shared/images/profile/service_icons/aim.png" alt="AIM" width="16" height="16" /></a>
+
+						<a href="aim:goim?screenname=dixp77" rel="me">AIM: dixp77</a>
+					</li>
+									<li class="module-list-item">
+						<a href="http://delicious.com/pauldix"><img src="/.shared/images/profile/service_icons/delicious.png" alt="Delicious" width="16" height="16" /></a>
+						<a href="http://delicious.com/pauldix" rel="me">Delicious: pauldix</a>
+					</li>
+									<li class="module-list-item">
+						<a href="http://www.facebook.com/profile.php?id=pcd2104%40columbia.edu"><img src="/.shared/images/profile/service_icons/facebook.png" alt="Facebook" width="16" height="16" /></a>
+
+						<a href="http://www.facebook.com/profile.php?id=pcd2104%40columbia.edu" rel="me">Facebook: pcd2104@columbia.edu</a>
+					</li>
+									<li class="module-list-item">
+						<a href="http://www.flickr.com/photos/pauldix/"><img src="/.shared/images/profile/service_icons/flickr.png" alt="Flickr" width="16" height="16" /></a>
+						<a href="http://www.flickr.com/photos/pauldix/" rel="me">Flickr: pauldix</a>
+					</li>
+									<li class="module-list-item">
+						<a href="msnim:chat?contact=paul%40pauldix.net"><img src="/.shared/images/profile/service_icons/msn.png" alt="MSN Messenger" width="16" height="16" /></a>
+
+						<a href="msnim:chat?contact=paul%40pauldix.net" rel="me">MSN Messenger: paul@pauldix.net</a>
+					</li>
+									<li class="module-list-item">
+						<a href="callto://paulcdix"><img src="/.shared/images/profile/service_icons/skype.png" alt="Skype" width="16" height="16" /></a>
+						<a href="callto://paulcdix" rel="me">Skype: paulcdix</a>
+					</li>
+									<li class="module-list-item">
+						<a href="http://twitter.com/pauldix"><img src="/.shared/images/profile/service_icons/twitter.png" alt="Twitter" width="16" height="16" /></a>
+
+						<a href="http://twitter.com/pauldix" rel="me">Twitter: pauldix</a>
+					</li>
+									<li class="module-list-item">
+						<a href="http://edit.yahoo.com/config/send_webmesg?.target=paulcdix"><img src="/.shared/images/profile/service_icons/yahoo.png" alt="Yahoo!" width="16" height="16" /></a>
+						<a href="http://edit.yahoo.com/config/send_webmesg?.target=paulcdix" rel="me">Yahoo!: paulcdix</a>
+					</li>
+				
+			</ul>
+		</div>
+
+	
+	
+</div>
+	<div class="module-archives module">
+		<h2 class="module-header"><a href="http://www.pauldix.net/archives.html">Archives</a></h2>
+		<div class="module-content">
+												<ul class="module-list">
+				
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/10/index.html">October 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/09/index.html">September 2009</a></li>
+
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/07/index.html">July 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/06/index.html">June 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/05/index.html">May 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/04/index.html">April 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/03/index.html">March 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/02/index.html">February 2009</a></li>
+
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/01/index.html">January 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2008/12/index.html">December 2008</a></li>
+									</ul>
+									<p class="module-more"><a href="http://www.pauldix.net/archives.html">More...</a></p>
+				
+				
+			
+		</div>
+	</div>
+
+<div class="module-widget module" id="widget-Widgetbox_1f1dca67-0b36-4e14-803b-6bfd184abac1">
+
+	<div class="module-content">
+    	<script type="text/javascript" src="http://widgetserver.com/syndication/subscriber/InsertPanel.js?panelId=1f1dca67-0b36-4e14-803b-6bfd184abac1"></script>
+	</div>
+</div>
+
+
+
+						</div>
+					</div>
+				</div>
+
+			</div>
+			
+
+		</div>
+	</div>
+	
+
+<script type="text/javascript">
+<!--
+var extra_happy = Math.floor(1000000000 * Math.random());
+document.write('<img src="http://www.typepad.com/t/stats?blog_id=108605&amp;user_id=280961&amp;page=' + escape(location.href) + '&amp;referrer=' + escape(document.referrer) + '&amp;i=' + extra_happy + '" width="1" height="1" alt="" style="position: absolute; top: 0; left: 0;" />');
+// -->
+</script>
+
+
+<!-- Start Quantcast tag -->
+<script type="text/javascript" src="http://edge.quantserve.com/quant.js"></script>
+<script type="text/javascript">_qoptions = { tags:"typepad.extended" }; _qacct="p-fcYWUmj5YbYKM"; quantserve();</script>
+<noscript>
+<a href="http://www.quantcast.com/p-fcYWUmj5YbYKM" target="_blank"><img src="http://pixel.quantserve.com/pixel/p-fcYWUmj5YbYKM.gif?tags=typepad.extended" style="display: none" border="0" height="1" width="1" alt="Quantcast"/></a>
+
+</noscript>
+<!-- End Quantcast tag -->
+
+<script src="http://cdn.media6degrees.com/static/ty2093.js" type="text/javascript"></script></body>
+</html>
+<!-- ph=1 -->
+<!-- nhm:from_kauri -->

--- a/spec/truffle-hog_spec.rb
+++ b/spec/truffle-hog_spec.rb
@@ -36,6 +36,12 @@ describe "parsing html" do
     feed_urls.should_not include("http://feeds.feedburner.com/PaulDixExplainsNothing/in_body/rss")
   end
   
+  it "parses relative urls for feeds, when asked" do
+    input = File.read("#{File.dirname(__FILE__)}/relative.html")
+    feed_urls = TruffleHog.parse_feed_urls(input, :all, :include_relative => true)
+    feed_urls.should include("/in_head/rss.xml")
+  end
+  
   it "returns atom feeds if rss is favored, but none are found"
   it "returns rss feeds if atom is favored, but none are found"
   


### PR DESCRIPTION
This commit adds the ability to ask TruffleHog to grab feed urls that aren't absolute. The default behaviour is still absolute urls only but this adds a bit more functionality if you ask for it.

(Fixed a dangling 'require' line in the spec)
