### PR TITLE
Case insensitivity and matching across whitespace

### DIFF
--- a/lib/truffle-hog.rb
+++ b/lib/truffle-hog.rb
@@ -19,17 +19,17 @@ module TruffleHog
     urls(html, "link", type) + urls(html, "a", type)
   end
   
-  def self.urls(html, tag, type)
-    tags = html.scan(/(<#{tag}.*?>)/).flatten
+  def self.urls(html, tag, type, include_relative = false)
+    tags = html.scan(/(<#{tag}[^>]*>)/i).flatten
     feed_tags = collect(tags, type)
     feed_tags.map do |tag|
-      matches = tag.match(/.*href=['"](.*?)['"].*/)
+      matches = tag.match(/.*href=['"](.*?)['"].*/i)
       if matches.nil?
         url = ""
       else
         url = matches[1]
       end
-      url =~ /^http.*/ ? url : nil
+      url =~ /^http.*/i ? url : nil
     end.compact
   end
   
@@ -38,6 +38,6 @@ module TruffleHog
   end
   
   def self.feed?(html, type)
-    html =~ /.*type=['"]application\/#{type}\+xml['"].*/
+    html =~ /.*type=['"]application\/#{type}\+xml['"].*/i
   end
 end

--- a/spec/different_case.html
+++ b/spec/different_case.html
@@ -1,0 +1,2345 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<TITLE>Techmeme</TITLE>
+<META HTTP-EQUIV="Refresh" CONTENT="1800">
+<META HTTP-EQUIV="Expires" CONTENT="now">
+<META NAME="description" CONTENT="The web's technology news site of record, Techmeme spotlights the hottest tech stories from all around the web on a single page.">
+<LINK REL="alternate" TYPE="application/rss+xml" TITLE="RSS" HREF="http://www.techmeme.com/index.xml" />
+<!-- Below line added for another case-insensitivity spec (not actually from Techmeme) -->
+<link rel="alternate" type="application/atom+xml" title="ATOM" href="HTTP://www.techmeme.com/atom.xml" />
+<LINK REL="SHORTCUT ICON" HREF="/img/favicon.ico">
+<link rel="image_src" href="http://www.techmeme.com/m/config/tech/iicon.gif" />
+<STYLE TYPE="text/css" MEDIA="all">
+img.sharebutton {position:relative;bottom:-1px;cursor:pointer;cursor:hand;}
+img.shareicon {min-height:16px;min-width:16px;}
+.sharebox {position:absolute;z-index:50;}
+.bdlight {position:relative;top:2px;left:2px;background-color:rgba(184, 182, 184, 0.4);-webkit-border-radius:7px;-moz-border-radius:7px;}
+.bddark {position:relative;top:-1px;left:-1px;background-color:rgba(128, 128, 128, 0.4);-webkit-border-radius:7px;-moz-border-radius:7px;}
+.shareboxcontent {position:relative;top:-1px;left:-1px;padding:6px 4px 4px;border:1px solid #1F4C63;background:#F3F3F3 none repeat;-webkit-border-radius:7px;-moz-border-radius:7px;}
+table.share {width:13.5em;}
+td.shareonhead {background:#1F4C63;color:white;font-weight:bold;}
+.twittershare {position:relative;bottom:3px;padding-left:0.15em;}
+.facebookshare {position:relative;bottom:3px;padding-left:0.15em;}
+td.linkto {border-top:1px solid gray;}
+table.permalinks {width:13.5em;}
+td.permalinkhead {background:#1F4C63;color:white;font-weight:bold;}
+td.permalink {padding:0;margin:0;}
+input.permalink {font-size:0.9em;width:14.5em;}
+a.share {text-decoration:underline;color:#345}
+a.share:visited {color:#345;}
+a.share:hover {background:#1F4C63;color:#fff;}
+BODY {font-family:arial;font-size:0.80em;margin:0;padding:0;}
+FORM {margin:0;}
+A IMG {border:none;}
+TD {font-family:arial;font-size:0.80em;} 
+H1 {margin:0;font-size:2em;font-family:tahoma;font-weight:bold;}
+H1 A:visited {color:#118;}
+A:link {color:#118;}
+A:visited {color:#927;}
+A:hover {background:#118;color:#fff;}
+.mls A:link {color:#448;}
+.mls A:visited {color:#957;}
+.mls A:hover {background-color:#118;color:#fff;}
+STRONG {font-weight:bolder;font-size:1.2em;line-height:1.1em;}
+.L1 {font-size:1.3em;font-weight:bolder;}
+.L2 {font-size:1.4em;font-weight:bolder;}
+.L3 {font-size:1.5em;font-weight:bold;line-height:1.1em;letter-spacing:-0.01em;}
+.L4 {font-size:1.7em;font-weight:bold;line-height:1.04em;letter-spacing:-0.02em;}
+.L5 {font-size:1.9em;font-weight:bold;line-height:1.02em;letter-spacing:-0.03em;}
+.ii {padding-top:0.2em;}
+.upd A.nfdl:link {color:#222;text-decoration:none;} 
+.upd A.nfdl:visited {color:#222;text-decoration:none;}
+.upd A.nfdl:hover {background:#118;color:#fff;}
+.relhed {margin-top:0.2em;margin-left:2em;}
+.relitems {margin:0 0 1em 3em;}
+.ill {float:right;padding:1em 0 0.5em 1em;}
+.hill {float:right;padding:0 0 0.5em 1em;}
+.sill {float:right;padding:1em 0 0 0.5em;}
+.item {padding-top:0.5em;padding-bottom:0.5em;clear:both;}
+.sitems .item {padding:0.8em 0;}
+.rsp {background:#e7e7de;border:solid 2px #f0f0f8;margin:0.5em 0;padding:0.5em;position:relative;left:-0.5em;}
+.rsp .item {padding:1em 0;}
+.rspd {color:#886;font-weight:bold;font-size:0.9em;text-align:right;text-transform:uppercase;}
+.heditem {padding-top:0.5em;padding-bottom:0.5em;}
+.hic {clear:both;}
+.halfcol DIV.heditem {padding-top:0.5em;padding-bottom:0.7em;}
+.halfcol {float:left;width:49.6%;}
+.clus {padding-top:0.5em;padding-bottom:0.5em;}
+.mlk {margin-top:0.1em;}
+.lnkr {margin-left:3.0em;padding-bottom:0.1em;}
+.lnkr A {font-weight:bolder;}
+.shr {margin-left:2.0em;padding:0.3em 0;}
+.shr A {padding:0.2em;border-color:#789;border-style:solid;border-width:1px;font-weight:bolder;font-size:0.9em;}
+.shr A:visited {color:#118;}
+.shr A:hover {background:#118;color:#fff;}
+A.oc {font-size:1.1em;text-decoration:none;color:#000;padding:0px 3px;}
+A.oc:visited {color:#000;}
+A.oc:hover {color:#000;}
+.show {border-color:#789;border-style:solid;border-width:1px;position:absolute;margin-left:-1.5em;font-weight:bold;}
+.drhed {color:#462;font-weight:bold;font-size:0.9em;padding-right:0.3em;}
+.rpan {float:left;width:38.9%;background:#fff;}
+.clearfloats {clear:both;width:100%;font-size:0.2em;}
+.nmpad {padding:1.5em 2em 0;}
+.mainpad {float:left;width:59%;padding-right:1.0em;background:url(/img/bakry.png);}
+.padl {padding-left:2em;}
+.padlr {padding:0 2em;}
+.upd {padding-bottom:0.5em;}
+.upd A {font-weight:bold}
+.upd A:visited {color:#118;}
+.upd A:hover {background-color:#118;color:#fff;}
+#preflink {text-align:right;padding:0.3em 3.8em;}
+#preflink A:visited {color:#118;}
+#preflink A:hover {background-color:#118;color:#fff;}
+#prefbox {margin:1.5em 0 0;padding-top:0.5em;padding-bottom:0.5em;border-style:solid none solid;border-width:4px;border-color:#2E4169;background:#dce3f0;text-align:center;}
+.rtxt {padding-left:0.5em;padding-right:0.5em;padding-bottom:0.5em;}
+.snh A {font-weight:bolder}
+.snh {padding:0.4em 0;}
+.new {padding-left:2em;color:#f00;font-style:italic;font-weight:bold;font-family:arial;font-size:0.9em;}
+.recent {padding-left:2em;color:#b02;font-style:italic;font-weight:bold;font-family:arial;font-size:0.9em;} 
+.ago {padding:0 0.5em 0;float:right;font-style:italic;font-size:0.9em;}
+.rnhdbak {letter-spacing:0.2em;text-transform:uppercase;font-family:arial;font-style:italic;font-weight:bold;color:#fff;}
+.rnhd1 {padding-left:0.6em;}
+.rnhd3 {padding-left:1em;}
+.rnbody {padding:0.7em 1.0em 0;}
+.rncont {margin-top:1.5em;max-width:1200px;}
+.rnbody P {margin:0.5em 0 0 0;}
+.nornbody {padding:0.7em 0.5em 0 0.5em;}
+.rnhang {text-align:right;margin-right:2.8em;padding:0.3em 1em 0.3em 1.5em;color:#fff;font-weight:bold;max-width:600px}
+.aboutrn .rnhdbak {background:url(/img/green/rnhdbak.png);}
+.aboutrn .rnhd1 {background:url(/img/green/rnhd1.png);}
+.aboutrn .rnhd2 {background:url(/img/green/rnhd2.png);}
+.aboutrn .rnhd3 {background:url(/img/green/rnhd3.png) no-repeat;}
+.aboutrn .rnftbak {background:url(/img/green/rnftbak.png) bottom left;}
+.aboutrn .rnbody {background:#d3e6d3;}
+.aboutrn .rnhang {background:url(/img/green/rnhang.png) bottom left;}
+.sponrn .rnhdbak {background:url(/img/y775/rnhdbak.png);}
+.sponrn .rnhd1 {background:url(/img/y775/rnhd1.png);}
+.sponrn .rnhd2 {background:url(/img/y775/rnhd2.png);}
+.sponrn .rnhd3 {background:url(/img/y775/rnhd3.png) no-repeat;}
+.sponrn .rnftbak {background:url(/img/y775/rnftbak.png) bottom left;}
+.sponrn .rnbody {background:#e7e7de;}
+.sponrn .rnhang {background:url(/img/y775/rnhang.png) bottom left;}
+.featrn .rnhdbak {background:url(/img/y775/rnhdbak.png);}
+.featrn .rnhd1 {background:url(/img/y775/rnhd1.png);}
+.featrn .rnhd2 {background:url(/img/y775/rnhd2.png);}
+.featrn .rnhd3 {background:url(/img/y775/rnhd3.png) no-repeat;}
+.featrn .rnftbak {background:url(/img/y775/rnftbak.png) bottom left;}
+.featrn .rnbody {background:#e7e7de;}
+.featrn .rnhang {background:url(/img/y775/rnhang.png) bottom left;}
+.col0rn .rnhdbak {background:url(/img/bl268/rnhdbak.png);}
+.col0rn .rnhd1 {background:url(/img/bl268/rnhd1.png);}
+.col0rn .rnhd2 {background:url(/img/bl268/rnhd2.png);}
+.col0rn .rnhd3 {background:url(/img/bl268/rnhd3.png) no-repeat;}
+.col0rn .rnftbak {background:url(/img/bl268/rnftbak.png) bottom left;}
+.col0rn .rnbody {background:#d7e7ee;}
+.col0rn .rnhang {background:url(/img/bl268/rnhang.png) bottom left;}
+.col1rn .rnhdbak {background:url(/img/bl248/rnhdbak.png);}
+.col1rn .rnhd1 {background:url(/img/bl248/rnhd1.png);}
+.col1rn .rnhd2 {background:url(/img/bl248/rnhd2.png);}
+.col1rn .rnhd3 {background:url(/img/bl248/rnhd3.png) no-repeat;}
+.col1rn .rnftbak {background:url(/img/bl248/rnftbak.png) bottom left;}
+.col1rn .rnbody {background:#dce3f0;}
+.col1rn .rnhang {background:url(/img/bl248/rnhang.png) bottom left;}
+DIV.pagecont {margin:2em auto 2em auto;max-width:86em;border-style:solid;border-width:0.6em 1px;border-color:#1F4C63;background:#fff;}
+DIV.bcp {background:url(/img/bakry.png);}
+BODY {background:#bbc;}
+#twitter_icon_preloader {display:none;background-image:url(/img/twitter_icon16.gif);background-repeat:no-repeat;}
+#facebook_icon_preloader {display:none;background-image:url(/img/facebook_icon16.gif);background-repeat:no-repeat;}
+CITE {font-weight:bold;font-size:0.9em;font-style:normal;}
+CITE {color:#468;}
+CITE A:link {color:#468;}
+CITE A:visited {color:#468;}
+CITE A:hover {color:#fff;background:#118;} 
+DIV.shr A {background-color:#def;}
+A.oc:hover {background-color:#def;}
+A.oc {background-color:#def;}
+DIV.hha {background:#efebdc;padding:0.3em;border-bottom:solid 2px #c5c5c5;text-align:center;display:none;}
+</STYLE>
+<STYLE TYPE="text/css" MEDIA="handheld">
+DIV.hha {display:block;}
+</STYLE>
+<script language="javascript">
+<!--
+// global
+var verticalName = 'Techmeme';
+var verticalUrl =  'http://www.techmeme.com/';
+var shortenerPrefix = 'http://techme.me/';
+var twitterViaStr = '(via @Techmeme)';
+var fbViaStr = '(via Techmeme.com)';
+var shareIconsPath = '/img/';
+var mouseOver = '';
+var ignoreMouseOver = false;
+var mouseOverButtonTimer;
+//functions
+function writeShareButton(shareBoxId) {
+document.write('<img class="sharebutton" src="' + shareIconsPath + 'share.png" onclick="toggleShareBoxDisplay(\'' + shareBoxId + 
+'\');" onmouseover="mouseOverShareButton(\'' + shareBoxId + '\');" onmouseout="mouseOutOfShareBoxAndButton(\'' + shareBoxId + '\');"' +
+' onmousedown="displayShareBox(event,\'' + shareBoxId + '\');">');
+}
+function mouseOverShareButton(shareBoxId) {
+mouseOver = shareBoxId + 'b';
+if (mouseOverButtonTimer) 
+clearTimeout(mouseOverButtonTimer);
+mouseOverButtonTimer = setTimeout(function() { isMouseStillOnShareButton(shareBoxId); }, 1000);
+}
+function isMouseStillOnShareButton(shareBoxId) {
+var shareBox = document.getElementById(shareBoxId);
+if (mouseOver == (shareBoxId + 'b') && shareBox.style.display == 'none') {
+initShareBoxIfNecessary(shareBoxId);
+shareBox.style.display = 'block';	
+}
+}
+function mouseOutOfShareBoxAndButton(shareBoxId) {
+mouseOver = '';
+setTimeout(function() { isMouseStillOffShareBoxAndButton(shareBoxId); }, 1000);
+}
+function isMouseStillOffShareBoxAndButton(shareBoxId) {
+if (!ignoreMouseOver && !(mouseOver == shareBoxId) && !(mouseOver == (shareBoxId + 'b')))
+document.getElementById(shareBoxId).style.display = 'none';
+}
+function toggleShareBoxDisplay(shareBoxId) {
+var shareBox = document.getElementById(shareBoxId);
+if (mouseOverButtonTimer && mouseOver == (shareBoxId + 'b')) 
+clearTimeout(mouseOverButtonTimer);
+initShareBoxIfNecessary(shareBoxId);
+if (shareBox.style.display == 'block')
+shareBox.style.display='none';
+else 
+shareBox.style.display='block';
+}
+function displayShareBox(event,shareBoxId) {
+if (detectRightClick(event)) {
+initShareBoxIfNecessary(shareBoxId);
+document.getElementById(shareBoxId).style.display='block';
+}
+}
+function initShareBoxIfNecessary(shareBoxId) {
+var shareBox = document.getElementById(shareBoxId);
+if (!shareBox.getAttribute('init')) {
+shareBox.innerHTML = getShareBoxHtml(shareBoxId);
+shareBox.onmouseover = function() { mouseOver = shareBoxId; };
+shareBox.onmouseout = function() { mouseOutOfShareBoxAndButton(shareBoxId); };
+sharePermalink(shareBoxId);
+populateShareBoxPermalinks(shareBoxId);
+shareBox.setAttribute('init','true');
+}
+}
+function sharePermalink(shareBoxId) {
+var shareBox = document.getElementById(shareBoxId);
+// on Twitter
+var twitterLink = document.getElementById(shareBoxId+'twl');
+twitterLink.href = "http://twitter.com/home?status=" + 
+encodeURIComponent(shareBox.getAttribute('head') + " " + shortenerPrefix + shareBox.getAttribute('spml'));
+twitterLink.title = shareBox.getAttribute('head') + " " + shortenerPrefix + shareBox.getAttribute('spml');
+// on Facebook
+var facebookLink = document.getElementById(shareBoxId+'fbl');
+facebookLink.href = "http://www.facebook.com/sharer.php?u=" + 
+encodeURIComponent(shortenerPrefix + shareBox.getAttribute('spml')) + "&t=" + encodeURIComponent(shareBox.getAttribute('head'));
+facebookLink.title = shareBox.getAttribute('head') + " " + shortenerPrefix + shareBox.getAttribute('spml');	
+}
+function shareSource(shareBoxId) {
+var shareBox = document.getElementById(shareBoxId);
+// on Twitter
+var twitterLink = document.getElementById(shareBoxId+'twl');
+twitterLink.href = "http://twitter.com/home?status=" + 
+encodeURIComponent(shareBox.getAttribute('head') + " http://bit.ly/" + shareBox.getAttribute('bitly') + " " + twitterViaStr);
+twitterLink.title = shareBox.getAttribute('head') + " http://bit.ly/" + shareBox.getAttribute('bitly') + " " + twitterViaStr;
+// on Facebook
+var facebookLink = document.getElementById(shareBoxId+'fbl');
+facebookLink.href = "http://www.facebook.com/sharer.php?u=" + 
+encodeURIComponent(shareBox.getAttribute('url')) + "&t=" + encodeURIComponent(shareBox.getAttribute('head') + " " + fbViaStr);
+facebookLink.title = shareBox.getAttribute('head') +  " " + shareBox.getAttribute('url') + " " + fbViaStr;
+}
+function populateShareBoxPermalinks(shareBoxId) {	
+// permalink
+var pml = document.getElementById(shareBoxId).getAttribute('pml');
+var pmlParts = pml.split('p');
+var permalink = verticalUrl + pmlParts[0] + '/p' + pmlParts[1] + '#a' + pml;
+document.getElementById(shareBoxId+'pml').value = permalink;
+document.getElementById(shareBoxId+'pmll').href = permalink;
+// short permalink
+var spml = document.getElementById(shareBoxId).getAttribute('spml');
+var shortPermalink = shortenerPrefix + spml;
+document.getElementById(shareBoxId+'spml').value = shortPermalink;
+document.getElementById(shareBoxId+'spmll').href = shortPermalink;
+}
+function selectTextboxContents(element) {
+element.focus();
+element.select();
+}
+function detectRightClick(event) {
+return ((event.which == null && event.button == 2) // IE
+|| event.which == 3) // others
+}
+function detectRightClickOnTextbox(event, element) {
+if (detectRightClick(event)) {
+ignoreMouseOver = true;
+selectTextboxContents(element);
+var shareBoxId = mouseOver;
+setTimeout(function() { ignoreMouseOver = false; setTimeout(function() { isMouseStillOffShareBoxAndButton(shareBoxId); }, 0);}, 4000);
+}
+}
+function getShareBoxHtml(shareBoxId) {
+return '<div class="bdlight"><div class="bddark"><div class="shareboxcontent">' +
+'<table class="share"><tr><td colspan="2" align="center" class="shareonhead">Share On:</td></tr>' +
+'<tr><td><img class="shareicon" src="' + shareIconsPath + 'twitter_icon16.gif"/><span class="twittershare"><a id="' + shareBoxId + 'twl" class="share" target="_blank">Twitter</a></span></td>' +
+'<td><img class="shareicon" src="' + shareIconsPath + 'facebook_icon16.gif"/><span class="facebookshare"><a id="' + shareBoxId + 'fbl" class="share" target="_blank">Facebook</a></span></td></tr>' +
+'<tr><td colspan="2" class="linkto">Link to:' +
+'<input type="radio" id="' + shareBoxId + 'ltp" name="' + shareBoxId + 'slt" value="permalink" onclick="sharePermalink(\'' + shareBoxId + '\')" checked/><label for="' + shareBoxId + 'ltp">' + verticalName + '</label>' +
+'<input type="radio" id="' + shareBoxId + 'lts" name="' + shareBoxId + 'slt" value="sourcelink" onclick="shareSource(\'' + shareBoxId + '\')" /><label for="' + shareBoxId + 'lts">Source</label></td></tr><tr></table>' +
+'<table class="permalinks"><tr><td colspan="2" align="center" class="permalinkhead">Permalink:</td></tr>' + 
+'<tr><td><a id="' + shareBoxId + 'pmll" class="share" target="_blank">Full</a></td><td align="right" class="permalink"><input id="' + shareBoxId + 'pml" type="text" class="permalink" readonly title="Ctrl+c to copy" onclick="selectTextboxContents(this);" onmousedown="detectRightClickOnTextbox(event, this);"></td></tr>' +
+'<tr><td><a id="' + shareBoxId + 'spmll" class="share" target="_blank">Short</a></td><td align="right" class="permalink"><input id="' + shareBoxId + 'spml" type="text" class="permalink" readonly title="Ctrl+c to copy" onclick="selectTextboxContents(this);" onmousedown="detectRightClickOnTextbox(event, this);"></td></tr></table>' +
+'</div></div></div>';
+}
+function preloadImage(id) {
+var a=document.createElement("div");
+a.id=id;
+document.body.appendChild(a)
+}
+function preloadShareImages(){
+preloadImage('twitter_icon_preloader');
+preloadImage('facebook_icon_preloader');
+}
+-->
+</script>
+<SCRIPT TYPE="text/javascript">
+<!--
+var pgrdad='November 19, 2010, 11:35 AM';
+var e;
+var nh=0;
+var ncl=0;
+var ctsidi=0;
+var nwcbe;
+var sdcbe;
+var sccbe;
+var fsne;
+var ckd='';
+function createCookie(name,value) {
+document.cookie = name+"="+value+"; expires=Tue, 19 Jan 2038 03:14:07 GMT; path=/"+ckd;
+}
+function readCookie(name) {
+var nameEQ = name + "=";
+var ca = document.cookie.split(';');
+for(var i=0;i < ca.length;i++) {
+var c = ca[i];
+while (c.charAt(0)==' ') c = c.substring(1,c.length);
+if (c.indexOf(nameEQ) == 0) return c.substring(nameEQ.length,c.length);
+}
+return null;
+}
+function eraseCookie(name) {
+document.cookie = name+"=; expires=Thu, 01-Jan-70 00:00:01 GMT; path=/"+ckd;
+}
+function xnwcb() { rnwcb(); svprefs(); }
+function xsdcb() { rsdcb(); svprefs(); }
+function xsccb() { rsccb(); svprefs(); }
+function xfsn() { rfsn(); svprefs(); }
+function rdprefs() {
+var cookie_val = readCookie('myprefs');
+nwcbe.checked = false;
+sdcbe.checked = false;
+sccbe.checked = false;
+fsne.selectedIndex=2;
+if (cookie_val) {
+var va = cookie_val.split('+');
+for(var i=0;i < va.length;i++) {
+var val = va[i];
+if (val == 'new_window') {
+nwcbe.checked = true;
+} else if (val == 'show_disc') {
+sdcbe.checked = true;
+} else if (val == 'show_cite') {
+sccbe.checked = true;
+} else if (val.indexOf('font_size') == 0) {
+fsne.selectedIndex=parseInt(val.charAt(9));
+}
+}
+}
+}
+function vfprefs() {
+var cookie_val = readCookie('myprefs');
+var ckdise = document.getElementById('ckdis');
+if (cookie_val) { ckdise.style.display = 'none'; } else { ckdise.style.display = 'block'; }
+}
+function svprefs() {
+var cookie_val = '';
+if (nwcbe.checked) {
+cookie_val += 'new_window';
+}
+if (sdcbe.checked) {
+if (cookie_val) { cookie_val += '+'; }
+cookie_val += 'show_disc';
+}
+if (sccbe.checked) {
+if (cookie_val) { cookie_val += '+'; }
+cookie_val += 'show_cite';
+}
+if (fsne.selectedIndex!=2) {
+if (cookie_val) { cookie_val += '+'; }
+cookie_val += 'font_size'+fsne.selectedIndex;
+}
+if (cookie_val == '') {
+eraseCookie('myprefs');
+} else {
+createCookie('myprefs', cookie_val);
+vfprefs();
+}
+}
+function rnwcb() {
+var where;
+if (nwcbe.checked)
+where = "_blank";
+else
+where = "_self";
+var jump_prefix = location.href.substring(0, location.href.length - location.hash.length) + '#';
+for (var i=0; i<=(document.links.length-1); i++) {
+var href = document.links[i].href;
+if ((href.indexOf("javascript:") != 0) && (href.indexOf(jump_prefix) != 0) && (href.search(/http:\/\/[a-z]+\.techmeme.com\/$/) != 0)) {
+document.links[i].target = where;
+}
+}
+}
+function td(id) {
+var e = document.getElementById(id);
+if (e.style.display == 'none') {
+e.style.display = 'block';
+} else {
+e.style.display = 'none';
+}
+}
+function ickd() {
+var dd = document.domain;
+if (dd) {
+var da = dd.split('.');
+var rd=da[da.length-2]+'.'+da[da.length-1];
+ckd='; domain=.'+rd;
+}
+}
+function uab() {
+var dr=document.referrer;
+if ( dr && (
+(dr.search(/\bstumbleupon\.com\//) != -1) || (
+(dr.search(/\b(techmeme|memeorandum|memorandum|memeorandom)\b/) == -1) &&
+( ((dr.search(/[.\/]google\./) != -1) && (dr.search(/\bq=/) != -1)) ||
+((dr.search(/\bsearch\.[a-z]+\./) != -1) && (dr.search(/\b(p|q|as_q)=/) != -1))
+)
+)
+)
+) {
+td('addbox');
+}
+}
+function init_all() {
+cmplu();
+td('preflink');
+nwcbe = document.getElementById('nwcb');
+sdcbe = document.getElementById('sdcb');
+sccbe = document.getElementById('sccb');
+fsne = document.getElementById('fsn');
+eraseCookie('prefs'); 
+ickd();
+rdprefs();
+rfsn();
+rsdcb();
+rsccb();
+rnwcb();
+hhash();
+if (!document.styleSheets) {
+document.getElementById('fscont').style.display = 'none';
+}
+uab();
+TiLTT();
+setTimeout("TeD()", TwTSE);
+preloadShareImages();
+}
+var TdTD = 400;
+var TnTB = 700;
+var TwTSE = 200;
+var TnOE = 3;
+var TwTBE = 0;
+var TwTCD = 150;
+var TsTS = '/do/lc';
+var TeTD = Number.MAX_VALUE;
+var TgETD = false;
+var TdE = new Array();
+var TE = function() {
+this.Tx = false;
+this.Ts = 0;
+this.Td = 0;
+this.toString = function() {
+return this.Ts + " " + this.Td;
+}
+}
+TE.Tc = function (a,b) {
+return a.Td - b.Td
+}
+var TcE_ = null;
+function TgXMLHR() {
+var Tx = false;
+if (window.XMLHttpRequest) {
+Tx = new XMLHttpRequest();
+} else {
+try
+{
+Tx = new ActiveXObject("Msxml2.XMLHTTP");
+}
+catch (ev)
+{
+try
+{
+Tx = new ActiveXObject("Microsoft.XMLHTTP");
+}
+catch (ev)
+{
+Tx = false;
+}
+}
+}
+return Tx;
+}
+function TeD() {
+TcE_ = new TE();
+TcE_.Tx = TgXMLHR();
+if (TcE_.Tx) {
+TcE_.Tx.open('POST', TsTS+'?tm=true', true);
+TcE_.Tx.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+TcE_.Tx.onreadystatechange = TeC;
+TcE_.Ts = new Date().getTime();
+TcE_.Tx.send(null);
+}
+}
+function TeC() {
+if (TcE_.Tx.readyState == 4 && TcE_.Tx.status == 200) {
+TcE_.Td = new Date().getTime() -  TcE_.Ts;
+TdE.push(TcE_);
+if (TdE.length < TnOE)
+setTimeout("TeD()", TwTBE);
+else
+TcED();
+}
+}
+function TcED() {
+TdE.sort(TE.Tc);
+TeTD = TdE[Math.floor(TnOE/2)].Td + TwTCD;
+TgETD= true;
+}
+function Tt(link) {
+if (isSafari() && TgETD && TeTD <= TdTD)
+{
+var TtD = TeTD;
+var Tx = TgXMLHR();
+if (Tx) {
+Tx.open('POST', TsTS+'?tm=false&href='+encodeURIComponent(link.href)+'&data='+TtD_(TtD),false);
+Tx.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+Tx.send(null);
+}
+}
+else if (!(TgETD && (TeTD >= TnTB)))
+{
+var TtD;
+if (!TgETD || (TgETD && (TeTD > TdTD)))
+TtD = TdTD;
+else
+TtD = TeTD;
+var Tx = TgXMLHR();
+if (Tx) {
+Tx.open('POST', TsTS+'?tm=false&href='+encodeURIComponent(link.href)+'&data='+TtD_(TtD),true);
+Tx.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
+Tx.send(null);
+var TcT = new Date();
+TeT = TcT.getTime() + TtD;
+while (TcT.getTime() < TeT)
+TcT = new Date();
+if (Tx.readyState != 4)
+Tx.abort();
+}
+}
+}
+function isSafari() {
+return ((navigator.appCodeName + navigator.appName + navigator.appVersion).search(/safari/i) != -1);
+}
+function TtD_(TtD) {
+var data =
+pgrdad + " " +
+TdTD + " " +
+TnTB + " " +
+TwTSE + " " +
+TnOE + " " +
+TwTBE + " " +
+TwTCD + " " +
+TeTD + " " +
+TgETD + " " +
+"(" + TdE + ") " +
+isSafari() + " " +
+TtD;
+return data;
+}
+function TiLTT() {
+var jump_prefix = location.href.substring(0, location.href.length - location.hash.length) + '#';
+for (var i=0; i<=(document.links.length-1); i++) {
+var href = document.links[i].href;
+if ((href.indexOf("javascript:") != 0) && (href.indexOf(jump_prefix) != 0))
+document.links[i].onclick = function(){Tt(this)};
+}
+}
+function cmplu() {
+var a=location.hash;
+if (!a) {
+if (location.href.search(/\/[0-9][0-9][0-9][0-9][0-9][0-9]\/p[0-9]*$/) != -1) {
+var pa = location.href.split('/');
+var di = pa.length - 2;
+var na = location.href + '#a' + pa[di] + pa[di+1];
+window.location.replace(na);
+}
+}
+}
+function hhash() { 
+var a=location.hash;
+if (a) {
+var i=a.substring(2,a.length);
+var je = document.getElementById(i);
+je.scrollIntoView(); 
+h(i);
+}
+}
+function clh(id) {
+ncl++;
+if (ncl == nh) {
+e.style.backgroundColor = 'transparent';
+}
+}
+function h(id) {
+if (e != null) {
+e.style.backgroundColor = 'transparent';
+}
+e = document.getElementById(id);
+e.style.backgroundColor = '#ff8';
+nh++;
+setTimeout('clh()',1500);
+}
+var nxbe;
+var pxbe;
+function bnxbe() {
+if (nxbe) {
+nxbe.style.display = 'block';
+pxbe = nxbe;
+}
+}
+function cnxbe() { nxbe = null; }
+function nnid(id) {
+if (pxbe && (!id || (pxbe != document.getElementById(id)))) { pxbe.style.display = 'none'; }
+}
+function dlbid(id) {
+nxbe = document.getElementById(id);
+if (nxbe) {
+if (pxbe && (pxbe != nxbe)) { pxbe.style.display = 'none'; }
+setTimeout('bnxbe()',50);
+}
+}
+function tgd(idp, p, ii) {
+var setd, setp;
+if (p) { setp = 'block'; setd = 'none'; }
+else { setp = 'none'; setd = 'block'; }
+var i, ei;
+if (ii) {
+i=ii; ei=ii;
+} else {
+i=1; ei=-1;
+document.getElementById(idp+'dxr').style.display = setd;
+document.getElementById(idp+'pxr').style.display = setp;
+}
+while (true) {
+var pe = document.getElementById(idp+'p'+i);
+if (pe == null) { return; }
+var de = document.getElementById(idp+'d'+i);
+pe.style.display = setp;
+de.style.display = setd;
+document.getElementById(idp+'dx'+i).style.display = 'none';
+if (i == ei) {
+if (!p) { ffbug(idp,p,i); }
+return;
+}
+i++;
+}
+}
+function ffbug(idp,p,i) {
+while (true) {
+i++;
+var pxe=document.getElementById(idp+'px'+i);
+if (pxe) {
+var d=pxe.style.display;
+if (d == 'block') {
+pxe.style.display = 'none';
+pxe.style.display = 'block';
+}
+} else {
+return;
+}
+}
+}
+function rsdcb() {
+var j=0;
+var setd, setp;
+if (sdcbe.checked) { setp = 'block'; setd = 'none'; }
+else { setp = 'none'; setd = 'block'; }
+while (j < 100) {
+var dxre = document.getElementById(j+'dxr');
+if (dxre) {
+dxre.style.display = setd;
+document.getElementById(j+'pxr').style.display = 'none';
+}
+var i=1;
+var pe = document.getElementById(j+'p'+i);
+while (pe != null) {
+pe.style.display = setp;
+document.getElementById(j+'px'+i).style.display = setd;
+document.getElementById(j+'d'+i).style.display = setd;
+i++;
+pe = document.getElementById(j+'p'+i);
+}
+j++;
+}
+}
+function rsccb() {
+var i=0;
+var setval;
+if (sccbe.checked) { setval = 'block'; } else { setval = 'none'; }
+while (true) {
+var te = document.getElementById('cts'+i);
+if (te == null) { return; }
+te.style.display = setval;
+i++;
+}
+}
+function rfsn() {
+if (document.styleSheets) {
+var ss = document.styleSheets[0];
+var fs=1.2-0.2*fsne.selectedIndex;
+if(ss.addRule) {
+ss.addRule("body","font-size:"+fs+"em");
+ss.addRule("td","font-size:"+fs+"em");
+} else {
+ss.insertRule("body,td{font-size:"+fs+"em}",ss.cssRules.length);
+}
+}
+}
+function cts(url, pp) {
+var re = /#/g;
+url = url.replace(re, '%23');
+url = url.replace(/&/g, '%26');
+var search_urls = [
+'http://blogs.icerocket.com/search?q=' + url,
+'http://blogsearch.google.com/blogsearch?q=' + url,
+'http://www.ask.com/blogsearch?q=' + url
+];
+var search_site_names = [
+'IceRocket',
+'Google',
+'Ask'
+];
+document.write('<DIV CLASS="mlk" ID="cts' + ctsidi + '" STYLE="display: none;"><SPAN CLASS="drhed">Link Search:</SPAN> ');
+ctsidi++;
+for (var i=0; i<search_urls.length; i++) {
+var next_search_url = search_urls[i];
+if (pp) {
+next_search_url = next_search_url.replace(/%23/g, '%2523');
+next_search_url = next_search_url.replace(/&/g, '%26');
+next_search_url = next_search_url.replace(/\?/g, '%3F');
+next_search_url = pp + next_search_url;
+}
+if (i>0) { document.write(', '); }
+if (i == search_urls.length-1)  { document.write('and '); }
+document.write('<A HREF="' + next_search_url + '">' + search_site_names[i] + '</A>');
+}
+document.write("</DIV>\n");
+}
+function smn() {
+document.getElementById('more_new').style.display='block';
+document.getElementById('show_more_new').style.display='none';
+}
+function hmn() {
+document.getElementById('more_new').style.display='none';
+document.getElementById('show_more_new').style.display='block';
+}
+// -->
+</SCRIPT>
+</HEAD>
+<BODY ONLOAD="init_all();">
+<DIV CLASS="hha">
+Check out <B><A HREF="http://www.techmeme.com/mini">Mini-Techmeme</A></B> for simple mobiles or
+<B><A HREF="http://www.techmeme.com/m">Techmeme Mobile</A></B> for modern smartphones.
+</DIV>
+<DIV CLASS="pagecont">
+<DIV CLASS="bcp">
+<DIV STYLE="float:right">
+<DIV CLASS="col0rn">
+<DIV CLASS="rnhang">
+11:35 AM ET, November 19, 2010
+</DIV>
+<DIV style="min-height:2em">
+<DIV ID="preflink" STYLE="display:none">
+<A HREF="javascript: td('aboutbox')">About</A> &nbsp;|&nbsp;
+<A HREF="javascript: td('prefbox')">Preferences</A>
+</DIV>
+</DIV>
+</DIV>
+<!--search box-->
+<div align="right" style="margin-right:2.3em;padding-top:1.2em">
+<form name="input" action="/search/query" method="get">
+<table>
+<tr>
+<td><input type="text" name="q" size="18"></td>
+<td><input type="submit" value="Search"></td>
+<td><span style="display:none"><input type="checkbox" name="wm" value="false" checked="checked"></span></td>
+</tr>
+</table>
+</form>
+</div>
+</DIV>
+<DIV CLASS="nmpad">
+<DIV ID="addbox" STYLE="display:none; float:right; margin:1em 3em 0 0; padding: 1em; background:#ffc; border: solid 1px #884;">
+Add <B>Techmeme</B> to:
+<A HREF="http://add.my.yahoo.com/rss?url=http://www.techmeme.com/index.xml">My Yahoo!</A>
+or
+<A HREF="http://fusion.google.com/add?feedurl=http://www.techmeme.com/index.xml">Google</A>
+</DIV>
+<H1>
+<A HREF="http://www.techmeme.com/" STYLE="background:transparent;"><IMG SRC="/img/techmeme.png" ALT="Techmeme"/></A>
+</H1>
+</DIV>
+<DIV ID="prefbox" STYLE="display: none">
+<FORM STYLE="margin:0">
+<B>Preferences:</B> &nbsp;
+<INPUT TYPE=checkbox ID="nwcb" ONCLICK="xnwcb();"><SPAN ONCLICK="nwcbe.checked=!nwcbe.checked;xnwcb();">Open Links in New Window</SPAN> &nbsp;
+<INPUT TYPE=checkbox ID="sdcb" ONCLICK="xsdcb();"><SPAN ONCLICK="sdcbe.checked=!sdcbe.checked;xsdcb();">Show Discussion Excerpts</SPAN> &nbsp;
+<INPUT TYPE=checkbox ID="sccb" ONCLICK="xsccb();"><SPAN ONCLICK="sccbe.checked=!sccbe.checked;xsccb();">Show Link Search</SPAN> &nbsp;
+<SPAN ID="fscont">
+&nbsp; Font Size:
+<SELECT ID="fsn" ONCHANGE="xfsn();">
+<OPTION>Very big</OPTION>
+<OPTION>Big</OPTION>
+<OPTION>Normal</OPTION>
+<OPTION>Small</OPTION>
+</SELECT>
+&nbsp; &nbsp; </SPAN>
+<INPUT TYPE=button VALUE="Done" ONCLICK="return td('prefbox');">
+</FORM>
+<DIV ID="ckdis" STYLE="display: none; padding-top: 0.5em;"><B>Note:</B> Because cookies are disabled, reloading this page will clear your settings.  Refer to <A HREF="http://www.google.com/cookies.html">this page</A> to reenable cookies.</DIV>
+</DIV>
+
+<DIV CLASS="mainpad">
+<DIV CLASS="padl">
+<DIV CLASS="col0rn">
+<DIV CLASS="rncont">
+<DIV CLASS="rnhdbak">
+<SPAN CLASS="rnhd1">&nbsp;</SPAN><SPAN CLASS="rnhd2">Top Items:</SPAN><SPAN CLASS="rnhd3">&nbsp;</SPAN>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="nornbody">
+<DIV CLASS="clus">
+<A NAME="a101119p21"></A>
+<DIV CLASS="item" ID="101119p21" ONMOUSEOVER="nnid('0dx1')">
+<A HREF="http://www.scientificamerican.com/article.cfm?id=long-live-the-web"><IMG CLASS="ill" SRC="/101119/i21.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p21#a101119p21" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s1');
+--></script>
+<CITE>Tim Berners-Lee / <A HREF="http://www.scientificamerican.com/">Scientific American</A>:</CITE>
+<span id="s1" pml="101119p21" spml="AJVK" bitly="b8PnTn" url="http://www.scientificamerican.com/article.cfm?id=long-live-the-web" head="Long Live the Web (@timberners_lee / Scientific American)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L5"><A HREF="http://www.scientificamerican.com/article.cfm?id=long-live-the-web">Long Live the Web</A></STRONG>&nbsp; &mdash;&nbsp; The Web is critical not merely to the digital revolution but to our continued prosperity&mdash;and even our liberty.&nbsp; Like democracy itself, it needs defending&nbsp; &mdash;&nbsp; The world wide web went live, on my physical desktop in Geneva, Switzerland, in December 1990.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.scientificamerican.com/article.cfm?id=long-live-the-web');
+--></SCRIPT>
+<DIV ID="0d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('0dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="0dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('0',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://ebiquity.umbc.edu/blogger/2010/11/19/tim-berners-lee-on-protecting-the-web-in-the-december-scientific-american/">UMBC ebiquity</A>, <SPAN CLASS="drhed">Thanks:</SPAN><A HREF="http://twitter.com/mathewi/status/5615756070883328">mathewi</A></SPAN>
+</DIV></DIV>
+<DIV ID="0p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="0px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('0',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Tim Finin / <A HREF="http://ebiquity.umbc.edu/blogger">UMBC ebiquity</A>:</CITE> &nbsp; <A HREF="http://ebiquity.umbc.edu/blogger/2010/11/19/tim-berners-lee-on-protecting-the-web-in-the-december-scientific-american/">Tim Berners-Lee on protecting the Web in the December Scientific American</A></DIV><DIV CLASS="lnkr"><SPAN CLASS="drhed">Thanks:</SPAN><A HREF="http://twitter.com/mathewi/status/5615756070883328">mathewi</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p22"></A>
+<A NAME="a101119p25"></A>
+<DIV CLASS="item" ID="101119p22" ONMOUSEOVER="nnid('1dx1')">
+<A HREF="http://kara.allthingsd.com/20101119/google-turns-its-local-eyes-to-groupon-but-who-else-could-enter-bidding/"><IMG CLASS="ill" SRC="/101119/i22.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p22#a101119p22" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s2');
+--></script>
+<CITE>Kara Swisher / <A HREF="http://kara.allthingsd.com/">BoomTown</A>:</CITE>
+<span id="s2" pml="101119p22" spml="AJVL" bitly="9k9asd" url="http://kara.allthingsd.com/20101119/google-turns-its-local-eyes-to-groupon-but-who-else-could-enter-bidding/" head="Google Turns Its Local Eyes to Groupon-But Who Else Could Enter Bidding? (@karaswisher / BoomTown)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L4"><A HREF="http://kara.allthingsd.com/20101119/google-turns-its-local-eyes-to-groupon-but-who-else-could-enter-bidding/">Google Turns Its Local Eyes to Groupon-But Who Else Could Enter Bidding?</A></STRONG>&nbsp; &mdash;&nbsp; According to multiple sources close to the situation, Google is in discussions with local deals powerhouse Groupon about buying it.&nbsp; &mdash;&nbsp; Without making the requisite joke about the deal of the day &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://kara.allthingsd.com/20101119/google-turns-its-local-eyes-to-groupon-but-who-else-could-enter-bidding/');
+--></SCRIPT>
+<DIV ID="1d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('1dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="1dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('1',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://vator.tv/news/2010-11-19-google-wants-groupon">VatorNews</A>, <A HREF="http://www.businessinsider.com/why-a-google-groupon-deal-would-be-a-huge-winner-2010-11">SAI</A>, <A HREF="http://news.cnet.com/8301-1023_3-20023353-93.html">CNET News</A>, <A HREF="http://blogs.barrons.com/techtraderdaily/2010/11/19/google-reportedly-in-talks-to-buy-groupon-for-over-3-billion/">Tech Trader Daily</A>, <A HREF="http://blogs.wsj.com/deals/2010/11/19/why-is-google-chasing-the-groupon-craze/">Deal Journal</A> and <A HREF="http://www.fiercemobilecontent.com/story/google-looking-acquire-social-commerce-powerhouse-groupon/2010-11-19">FierceMobileContent</A></SPAN>
+</DIV></DIV>
+<DIV ID="1p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="1px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('1',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Faith Merino / <A HREF="http://vator.tv/news/">VatorNews</A>:</CITE> &nbsp; <A HREF="http://vator.tv/news/2010-11-19-google-wants-groupon">Google wants Groupon</A></DIV><DIV CLASS="lnkr"><CITE>Nick Saint / <A HREF="http://www.businessinsider.com/sai">SAI: Silicon Alley Insider</A>:</CITE> &nbsp; <A HREF="http://www.businessinsider.com/why-a-google-groupon-deal-would-be-a-huge-winner-2010-11">Why A Google-Groupon Deal Would Be A Huge Winner - Even At $5 Billion Plus</A></DIV><DIV CLASS="lnkr"><CITE>Kara Swisher / <A HREF="http://news.cnet.com/">CNET News</A>:</CITE> &nbsp; <A HREF="http://news.cnet.com/8301-1023_3-20023353-93.html">Google turns its local eyes to Groupon</A></DIV><DIV CLASS="lnkr"><CITE>Eric Savitz / <A HREF="http://blogs.barrons.com/techtraderdaily">Tech Trader Daily</A>:</CITE> &nbsp; <A HREF="http://blogs.barrons.com/techtraderdaily/2010/11/19/google-reportedly-in-talks-to-buy-groupon-for-over-3-billion/">Google Reportedly In Talks To Buy Groupon For Over $3 Billion</A></DIV><DIV CLASS="lnkr"><CITE>Shira Ovide / <A HREF="http://blogs.wsj.com/deals">Deal Journal</A>:</CITE> &nbsp; <A HREF="http://blogs.wsj.com/deals/2010/11/19/why-is-google-chasing-the-groupon-craze/">Why is Google Chasing the Groupon Craze?</A></DIV><DIV CLASS="lnkr"><CITE>Jason Ankeny / <A HREF="http://www.fiercemobilecontent.com/news/frontpage">FierceMobileContent</A>:</CITE> &nbsp; <A HREF="http://www.fiercemobilecontent.com/story/google-looking-acquire-social-commerce-powerhouse-groupon/2010-11-19">Google looking to acquire social commerce powerhouse Groupon</A></DIV><DIV CLASS="shr" ID="1dxr" STYLE="display:block;"><A HREF="javascript:tgd('1',true)">&raquo; All Related Discussion</A></DIV><DIV CLASS="shr" ID="1pxr" STYLE="display:none;"><A HREF="javascript:tgd('1',false)">&laquo; Hide All Related Discussion</A></DIV></DIV>
+</DIV>
+</DIV>
+<DIV CLASS="relhed"><SPAN CLASS="drhed">RELATED:</SPAN></DIV><DIV CLASS="relitems">
+<DIV CLASS="item" ID="101119p25" ONMOUSEOVER="nnid('1dx2')">
+<A HREF="http://www.businessinsider.com/google-buy-groupon-and-twitter-and-foursquare-2010-11"><IMG CLASS="ill" SRC="/101119/i25.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p25#a101119p25" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s3');
+--></script>
+<CITE>Henry Blodget / <A HREF="http://www.businessinsider.com/sai">SAI</A>:</CITE><SPAN CLASS="recent">20&nbsp;minutes&nbsp;ago</SPAN>
+<span id="s3" pml="101119p25" spml="AJVO" bitly="aLLst2" url="http://www.businessinsider.com/google-buy-groupon-and-twitter-and-foursquare-2010-11" head="Hell, Yes, Google Should Buy Groupon. And Twitter. And Foursquare... (@hblodget / SAI)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.businessinsider.com/google-buy-groupon-and-twitter-and-foursquare-2010-11">Hell, Yes, Google Should Buy Groupon.&nbsp; And Twitter.&nbsp; And Foursquare...</A></STRONG>&nbsp; Google is in talks to buy Groupon for more than $3 billion, Kara Swisher reports.&nbsp; &mdash;&nbsp; Good.&nbsp; &mdash;&nbsp; Google offered $2.5-$4 billion to buy Twitter a few months ago, Nicholas Carlson reports.&nbsp; &mdash;&nbsp; Also good.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.businessinsider.com/google-buy-groupon-and-twitter-and-foursquare-2010-11');
+--></SCRIPT>
+<DIV ID="1d2"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('1dx2')" ONMOUSEOUT="cnxbe()">
+<DIV ID="1dx2" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('1',true,2)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.loopinsight.com/2010/11/18/google-offered-4-billion-for-twitter/">The Loop</A></SPAN>
+</DIV></DIV>
+<DIV ID="1p2" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="1px2" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('1',false,2)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Jim Dalrymple / <A HREF="http://www.loopinsight.com/">The Loop</A>:</CITE> &nbsp; <A HREF="http://www.loopinsight.com/2010/11/18/google-offered-4-billion-for-twitter/">Google offered $4 billion for Twitter</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101118p75"></A>
+<DIV CLASS="item" ID="101118p75" ONMOUSEOVER="nnid('2dx1')">
+<A HREF="http://www.reuters.com/article/idUSTRE6AI05820101119"><IMG CLASS="ill" SRC="/101118/i75.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p75#a101118p75" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s4');
+--></script>
+<CITE>Alexei Oreskovic / <A HREF="http://news.yahoo.com/i/578">Reuters</A>:</CITE>
+<span id="s4" pml="101118p75" spml="AJGA" bitly="dyooSe" url="http://www.reuters.com/article/idUSTRE6AI05820101119" head="Wanted: more than 2,000, in Google hiring spree (@lexnfx / Reuters)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L3"><A HREF="http://www.reuters.com/article/idUSTRE6AI05820101119">Wanted: more than 2,000, in Google hiring spree</A></STRONG>&nbsp; &mdash;&nbsp; (Reuters) - Google Inc plans to hire more than 2,000 people around the globe, bumping up its workforce as it expands into new markets and battles for talent with faster-growing rivals.&nbsp; &mdash;&nbsp; The world's largest Internet search engine &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.reuters.com/article/idUSTRE6AI05820101119');
+--></SCRIPT>
+<DIV ID="2d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('2dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="2dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('2',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.businessinsider.com/my-nightmare-interviews-with-google-2010-11">SAI</A>, <A HREF="http://blog.louisgray.com/2010/11/facebook-recruiting-video-promises.html">louisgray.com</A>, <A HREF="http://www.techeye.net/business/google-goes-on-hiring-spree">TechEye</A> and <A HREF="http://www.slashgear.com/want-a-job-google-plans-on-hiring-2000-employees-around-the-world-18115012/">SlashGear</A></SPAN>
+</DIV></DIV>
+<DIV ID="2p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="2px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('2',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Alyson Shontell / <A HREF="http://www.businessinsider.com/sai">SAI</A>:</CITE> &nbsp; <A HREF="http://www.businessinsider.com/my-nightmare-interviews-with-google-2010-11">My Nightmare Interviews With Google</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://blog.louisgray.com/">Louis Gray</A>:</CITE> &nbsp; <A HREF="http://blog.louisgray.com/2010/11/facebook-recruiting-video-promises.html">Facebook Recruiting Video Promises Bold Vision, Potential</A></DIV><DIV CLASS="lnkr"><CITE>Nick Farrell / <A HREF="http://www.techeye.net/">TechEye</A>:</CITE> &nbsp; <A HREF="http://www.techeye.net/business/google-goes-on-hiring-spree">Google goes on hiring spree</A></DIV><DIV CLASS="lnkr"><CITE>Chris Burns / <A HREF="http://www.slashgear.com/">SlashGear</A>:</CITE> &nbsp; <A HREF="http://www.slashgear.com/want-a-job-google-plans-on-hiring-2000-employees-around-the-world-18115012/">Want a Job? Google Plans on Hiring 2,000 Employees Around the World</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p13"></A>
+<DIV CLASS="item" ID="101119p13" ONMOUSEOVER="nnid('3dx1')">
+<A HREF="http://www.androidcentral.com/htc-merge-360-degree-view-appears-quickly-disappears-verizons-site"><IMG CLASS="ill" SRC="/101119/i13.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p13#a101119p13" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s5');
+--></script>
+<CITE>Phil Nickinson / <A HREF="http://www.androidcentral.com/feed">Android Central</A>:</CITE>
+<span id="s5" pml="101119p13" spml="AJVC" bitly="ctjpFD" url="http://www.androidcentral.com/htc-merge-360-degree-view-appears-quickly-disappears-verizons-site" head="HTC Merge 360-degree view appears, quickly disappears from Verizon's site (@philnickinson /..." class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L2"><A HREF="http://www.androidcentral.com/htc-merge-360-degree-view-appears-quickly-disappears-verizons-site">HTC Merge 360-degree view appears, quickly disappears from Verizon's site</A></STRONG>&nbsp; &mdash;&nbsp; Need another sign that the HTC Merge is nearing release?&nbsp; How about a 360-degree look to go along with our previous hands-on and video preview.&nbsp; It popped up on Verizon's website today and was quickly pulled, but that's just not how we do things around here.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.androidcentral.com/htc-merge-360-degree-view-appears-quickly-disappears-verizons-site');
+--></SCRIPT>
+<DIV ID="3d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('3dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="3dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('3',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.techeye.net/mobile/360-degree-view-of-htc-merge-leaked-by-verizon">TechEye</A>, <A HREF="http://thenextweb.com/mobile/2010/11/19/htc-merge-mistakenly-published-in-360-degree-verizon-gallery/">The Next Web</A>, <A HREF="http://www.electronista.com/articles/10/11/18/content.quickly.pulled.from.site/">Electronista</A>, <A HREF="http://www.androidpolice.com/2010/11/19/360-view-of-htc-merge-discovered-on-verizons-site-quickly-pulled/">Android Police</A>, <A HREF="http://phonereport.info/htc-merge-verizon-release-date-approaches/">PhoneReport v2.0</A>, <A HREF="http://www.mobileburn.com/rumors.jsp?Id=11766">MobileBurn.com</A>, <A HREF="http://www.engadget.com/2010/11/19/htc-merge-emerges-on-verizon-site-a-little-early/">Engadget</A>, <A HREF="http://www.fonehome.co.uk/2010/11/19/htc-merge-leaked-android-2-2-plus-a-qwerty-anyone/">Fonehome.co.uk</A>, <A HREF="http://www.slashgear.com/verizon-htc-merge-gets-premature-preview-19114972/">SlashGear</A>, <A HREF="http://www.pocket-lint.com/news/36884/htc-merge-leaked-pics-video">Pocket-lint</A>, <A HREF="http://www.newlaunches.com/archives/verizon_prematurely_shows_off_htc_merge_on_site_pulls_it_down_later.php">Newlaunches.com</A>, <A HREF="http://www.dailytech.com/article.aspx?newsid=20201">DailyTech</A>, <A HREF="http://www.droid-life.com/2010/11/18/htc-merge-appears-on-verizon-site-for-a-quick-photo/">Droid Life</A>, <A HREF="http://www.phonearena.com/news/HTC-Merge-emerged-in-its-full-glory-on-the-Verizon-site-taken-down-swiftly_id14777">PhoneArena</A>, <A HREF="http://www.intomobile.com/2010/11/18/htc-merge-verizon-video/">IntoMobile</A>, <A HREF="http://www.phonedog.com/2010/11/18/htc-merge-does-a-full-360-degree-turn-on-verizon-s-site-is-quickly-yanked/">PhoneDog.com</A>, <A HREF="http://phandroid.com/2010/11/18/htc-merge-appears-on-verizons-site/">Android Phone Fans</A>, <A HREF="http://www.phonesreview.co.uk/2010/11/19/android-htc-merge-appears-and-vanishes-video/">Phones Review</A> and <A HREF="http://gizmodo.com/5694125/">Gizmodo</A></SPAN>
+</DIV></DIV>
+<DIV ID="3p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="3px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('3',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Dean Wilson / <A HREF="http://www.techeye.net/">TechEye</A>:</CITE> &nbsp; <A HREF="http://www.techeye.net/mobile/360-degree-view-of-htc-merge-leaked-by-verizon">360 degree view of HTC Merge leaked by Verizon</A></DIV><DIV CLASS="lnkr"><CITE>Matt Brian / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/mobile/2010/11/19/htc-merge-mistakenly-published-in-360-degree-verizon-gallery/">HTC Merge mistakenly published in 360-degree Verizon gallery</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.electronista.com/">Electronista</A>:</CITE> &nbsp; <A HREF="http://www.electronista.com/articles/10/11/18/content.quickly.pulled.from.site/">Verizon slips HTC Merge pictures ahead of official launch</A></DIV><DIV CLASS="lnkr"><CITE>Aaron Gingrich / <A HREF="http://www.androidpolice.com/">Android Police</A>:</CITE> &nbsp; <A HREF="http://www.androidpolice.com/2010/11/19/360-view-of-htc-merge-discovered-on-verizons-site-quickly-pulled/">360&deg; View Of HTC Merge Discovered On Verizon's Site, Quickly Pulled</A></DIV><DIV CLASS="lnkr"><CITE>Meraj Chhaya / <A HREF="http://phonereport.info/">PhoneReport v2.0</A>:</CITE> &nbsp; <A HREF="http://phonereport.info/htc-merge-verizon-release-date-approaches/">HTC Merge Verizon Release Date Approaches</A></DIV><DIV CLASS="lnkr"><CITE>Todd Haselton / <A HREF="http://www.mobileburn.com/">MobileBurn.com</A>:</CITE> &nbsp; <A HREF="http://www.mobileburn.com/rumors.jsp?Id=11766">Verizon HTC Merge Android smartphone leaked</A></DIV><DIV CLASS="lnkr"><CITE>Vlad Savov / <A HREF="http://www.engadget.com/">Engadget</A>:</CITE> &nbsp; <A HREF="http://www.engadget.com/2010/11/19/htc-merge-emerges-on-verizon-site-a-little-early/">HTC Merge emerges on Verizon site a little early</A></DIV><DIV CLASS="lnkr"><CITE>Andrew / <A HREF="http://www.fonehome.co.uk/">Fonehome.co.uk</A>:</CITE> &nbsp; <A HREF="http://www.fonehome.co.uk/2010/11/19/htc-merge-leaked-android-2-2-plus-a-qwerty-anyone/">HTC Merge leaked &mdash; Android 2.2 plus a Qwerty, anyone?</A></DIV><DIV CLASS="lnkr"><CITE>Chris Davies / <A HREF="http://www.slashgear.com/">SlashGear</A>:</CITE> &nbsp; <A HREF="http://www.slashgear.com/verizon-htc-merge-gets-premature-preview-19114972/">Verizon HTC Merge gets premature preview</A></DIV><DIV CLASS="lnkr"><CITE>Paul Lamkin / <A HREF="http://www.pocket-lint.com/">Pocket-lint</A>:</CITE> &nbsp; <A HREF="http://www.pocket-lint.com/news/36884/htc-merge-leaked-pics-video">HTC Merge leaked pics and video</A></DIV><DIV CLASS="lnkr"><CITE>Stephen / <A HREF="http://www.newlaunches.com/">Newlaunches.com</A>:</CITE> &nbsp; <A HREF="http://www.newlaunches.com/archives/verizon_prematurely_shows_off_htc_merge_on_site_pulls_it_down_later.php">Verizon prematurely shows off HTC Merge on site, pulls it down later</A></DIV><DIV CLASS="lnkr"><CITE>Mark Kurlyandchik / <A HREF="http://www.dailytech.com/">DailyTech</A>:</CITE> &nbsp; <A HREF="http://www.dailytech.com/article.aspx?newsid=20201">HTC Merge Goes for a Spin</A></DIV><DIV CLASS="lnkr"><CITE>Kellex / <A HREF="http://www.droid-life.com/">Droid Life</A>:</CITE> &nbsp; <A HREF="http://www.droid-life.com/2010/11/18/htc-merge-appears-on-verizon-site-for-a-quick-photo/">HTC Merge Appears on Verizon Site for a Quick Photo</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.phonearena.com/">Phone Arena</A>:</CITE> &nbsp; <A HREF="http://www.phonearena.com/news/HTC-Merge-emerged-in-its-full-glory-on-the-Verizon-site-taken-down-swiftly_id14777">HTC Merge emerged in its full glory on the Verizon site, taken down swiftly</A></DIV><DIV CLASS="lnkr"><CITE>Blake Stimac / <A HREF="http://www.intomobile.com/">IntoMobile</A>:</CITE> &nbsp; <A HREF="http://www.intomobile.com/2010/11/18/htc-merge-verizon-video/">HTC Merge appears on Verizon's site, gets pulled quickly [video]</A></DIV><DIV CLASS="lnkr"><CITE>Alex Wagner / <A HREF="http://www.phonedog.com/blog/default.aspx">PhoneDog.com</A>:</CITE> &nbsp; <A HREF="http://www.phonedog.com/2010/11/18/htc-merge-does-a-full-360-degree-turn-on-verizon-s-site-is-quickly-yanked/">HTC Merge does a full 360-degree turn on Verizon's site, is quickly yanked</A></DIV><DIV CLASS="lnkr"><CITE>Kevin Krause / <A HREF="http://phandroid.com/">Android Phone Fans</A>:</CITE> &nbsp; <A HREF="http://phandroid.com/2010/11/18/htc-merge-appears-on-verizons-site/">HTC Merge Appears on Verizon's Site</A></DIV><DIV CLASS="lnkr"><CITE>James / <A HREF="http://www.phonesreview.co.uk/">Phones Review</A>:</CITE> &nbsp; <A HREF="http://www.phonesreview.co.uk/2010/11/19/android-htc-merge-appears-and-vanishes-video/">Android HTC Merge Appears and Vanishes: Video</A></DIV><DIV CLASS="lnkr"><CITE>Kat Hannaford / <A HREF="http://gizmodo.com/">Gizmodo</A>:</CITE> &nbsp; <A HREF="http://gizmodo.com/5694125/">HTC Merge Surfaces on Verizon's Site, Only To Be Yanked</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p16"></A>
+<A NAME="a101119p4"></A>
+<DIV CLASS="item" ID="101119p16" ONMOUSEOVER="nnid('4dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p16#a101119p16" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s6');
+--></script>
+<CITE>Ingrid Lee / <A HREF="http://www.digitimes.com/">DigiTimes</A>:</CITE>
+<span id="s6" pml="101119p16" spml="AJVF" bitly="d9zlrj" url="http://www.digitimes.com/news/a20101118PD211.html" head="Sources reveal some PCB suppliers for iPad 2 (Ingrid Lee / DigiTimes)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L2"><A HREF="http://www.digitimes.com/news/a20101118PD211.html">Sources reveal some PCB suppliers for iPad 2</A></STRONG>&nbsp; &mdash;&nbsp; Ibiden, Tripod Technology and TTM Technologies have been named as the initial PCB suppliers for a second-generation Apple tablet PC, which is expected to be launched in the first quarter of 2011.&nbsp; Four more suppliers will be added to the list in February 2011 &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.digitimes.com/news/a20101118PD211.html');
+--></SCRIPT>
+<DIV ID="4d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('4dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="4dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('4',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.9to5mac.com/36626/samsung-chip-choice-hints-arm-a9-for-ipad-2-0">9 to 5 Mac</A>, <A HREF="http://www.phonedog.com/2010/11/19/rumor-ipad-2-launching-in-q1-2011-with-global-radios-and-front-facing-camera/">PhoneDog.com</A>, <A HREF="http://news.softpedia.com/news/PCB-Suppliers-Sign-with-Apple-to-Make-the-iPad-2G-Report-167638.shtml">Softpedia News</A>, <A HREF="http://www.macstories.net/news/ipad-2-part-suppliers-possibly-revealed/">MacStories</A>, <A HREF="http://www.bgr.com/2010/11/19/ipad-2-initial-parts-suppliers-revealed/">BGR</A>, <A HREF="http://erictric.com/2010/11/19/initial-ipad-2-pcb-suppliers-revealed/">Erictric</A>, <A HREF="http://www.tipb.com/2010/11/19/ipad-2-component-manufacturers-revealed/">TiPb</A>, <A HREF="http://www.crunchgear.com/2010/11/18/suppliers-named-for-q1-2011-ipad-refresh/">CrunchGear</A>, <A HREF="http://www.pocketgamer.biz/r/PG.Biz/Apple+iPad/news.asp?c=25296">www.pocketgamer.biz</A>, <A HREF="http://www.slashgear.com/ipad-2-suppliers-leaked-ahead-of-feb-2011-mass-production-19115037/">SlashGear</A>, <A HREF="http://thenextweb.com/apple/2010/11/19/ipad-2-ready-for-production-q1-2011/">The Next Web</A>, <A HREF="http://www.coveringweb.com/2010/11/ipad-2-ready-for-production-in-q1-2011.html">Covering Web</A>, <A HREF="http://electricpig.co.uk/2010/11/19/ipad-carbon-fiber-design-revealed/">Electricpig.co.uk</A>, <A HREF="http://www.tuaw.com/2010/11/19/next-generation-ipad-parts-suppliers-supposedly-named/">TUAW</A>, <A HREF="http://www.i4u.com/42745/apple-ipad-2-shipment-ramp-february-2011">I4U News</A>, <A HREF="http://techreport.com/discussions.x/20018">The Tech Report</A>, <A HREF="http://www.electronista.com/articles/10/11/18/next.ipad.to.scale.in.february/">Electronista</A>, <A HREF="http://www.itproportal.com/2010/11/19/apple-ipad-2-tablet-component-suppliers-point-q1-2011-launch/">ITProPortal</A>, <A HREF="http://www.phonesreview.co.uk/2010/11/19/apple-ipad-is-much-loved-tablet/">Phones Review</A> and <A HREF="http://www.huffingtonpost.com/2010/11/19/ipad-2-rumors-heat-up-new_n_785923.html">The Huffington Post</A></SPAN>
+</DIV></DIV>
+<DIV ID="4p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="4px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('4',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Jonny Evans / <A HREF="http://www.9to5mac.com/">9 to 5 Mac</A>:</CITE> &nbsp; <A HREF="http://www.9to5mac.com/36626/samsung-chip-choice-hints-arm-a9-for-ipad-2-0">Samsung chip choice hints ARM A9 for iPad 2.0</A></DIV><DIV CLASS="lnkr"><CITE>Alex Wagner / <A HREF="http://www.phonedog.com/blog/default.aspx">PhoneDog.com</A>:</CITE> &nbsp; <A HREF="http://www.phonedog.com/2010/11/19/rumor-ipad-2-launching-in-q1-2011-with-global-radios-and-front-facing-camera/">Rumor: iPad 2 launching in Q1 2011 with global radios and front-facing camera</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.softpedia.com/">Softpedia News</A>:</CITE> &nbsp; <A HREF="http://news.softpedia.com/news/PCB-Suppliers-Sign-with-Apple-to-Make-the-iPad-2G-Report-167638.shtml">PCB Suppliers Sign with Apple to Make the iPad 2G - Report</A></DIV><DIV CLASS="lnkr"><CITE>Chris Herbert / <A HREF="http://www.macstories.net/">MacStories</A>:</CITE> &nbsp; <A HREF="http://www.macstories.net/news/ipad-2-part-suppliers-possibly-revealed/">iPad 2 Part Suppliers Possibly Revealed?</A></DIV><DIV CLASS="lnkr"><CITE>Zach Epstein / <A HREF="http://www.bgr.com/">BGR</A>:</CITE> &nbsp; <A HREF="http://www.bgr.com/2010/11/19/ipad-2-initial-parts-suppliers-revealed/">iPad 2 initial parts suppliers revealed</A></DIV><DIV CLASS="lnkr"><CITE>Eric Calouro / <A HREF="http://erictric.com/">Erictric</A>:</CITE> &nbsp; <A HREF="http://erictric.com/2010/11/19/initial-ipad-2-pcb-suppliers-revealed/">Initial iPad 2 PCB Suppliers Revealed</A></DIV><DIV CLASS="lnkr"><CITE>Chris Oldroyd / <A HREF="http://www.tipb.com/">TiPb</A>:</CITE> &nbsp; <A HREF="http://www.tipb.com/2010/11/19/ipad-2-component-manufacturers-revealed/">iPad 2 component manufacturers revealed?</A></DIV><DIV CLASS="lnkr"><CITE>Devin Coldewey / <A HREF="http://www.crunchgear.com/">CrunchGear</A>:</CITE> &nbsp; <A HREF="http://www.crunchgear.com/2010/11/18/suppliers-named-for-q1-2011-ipad-refresh/">Suppliers Named For Q1 2011 iPad Refresh</A></DIV><DIV CLASS="lnkr"><CITE>Keith Andrew / <A HREF="http://www.pocketgamer.biz/">www.pocketgamer.biz</A>:</CITE> &nbsp; <A HREF="http://www.pocketgamer.biz/r/PG.Biz/Apple+iPad/news.asp?c=25296">Apple signs up three suppliers as iPad 2 looks set for Q1 2011 debut</A></DIV><DIV CLASS="lnkr"><CITE>Chris Davies / <A HREF="http://www.slashgear.com/">SlashGear</A>:</CITE> &nbsp; <A HREF="http://www.slashgear.com/ipad-2-suppliers-leaked-ahead-of-feb-2011-mass-production-19115037/">iPad 2 suppliers leaked ahead of Feb 2011 mass production?</A></DIV><DIV CLASS="lnkr"><CITE>Tris Hussey / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/apple/2010/11/19/ipad-2-ready-for-production-q1-2011/">iPad 2 Ready for Production Q1 2011?</A></DIV><DIV CLASS="lnkr"><CITE>Ahmed Omar / <A HREF="http://www.coveringweb.com/">Covering Web</A>:</CITE> &nbsp; <A HREF="http://www.coveringweb.com/2010/11/ipad-2-ready-for-production-in-q1-2011.html">iPad 2 Ready for Production in Q1 2011</A></DIV><DIV CLASS="lnkr"><CITE>Mic Wright / <A HREF="http://electricpig.co.uk/">Electricpig.co.uk</A>:</CITE> &nbsp; <A HREF="http://electricpig.co.uk/2010/11/19/ipad-carbon-fiber-design-revealed/">iPad: carbon fiber design revealed</A></DIV><DIV CLASS="lnkr"><CITE>Dave Caolo / <A HREF="http://www.tuaw.com/">TUAW</A>:</CITE> &nbsp; <A HREF="http://www.tuaw.com/2010/11/19/next-generation-ipad-parts-suppliers-supposedly-named/">Next-generation iPad parts suppliers supposedly named</A></DIV><DIV CLASS="lnkr"><CITE>Luigi Lugmayr / <A HREF="http://www.i4u.com/">I4U News</A>:</CITE> &nbsp; <A HREF="http://www.i4u.com/42745/apple-ipad-2-shipment-ramp-february-2011">Apple iPad 2 Shipment to ramp up February 2011</A></DIV><DIV CLASS="lnkr"><CITE>Cyril Kowaliski / <A HREF="http://techreport.com/">The Tech Report</A>:</CITE> &nbsp; <A HREF="http://techreport.com/discussions.x/20018">Second-gen iPad coming next quarter, says report</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.electronista.com/">Electronista</A>:</CITE> &nbsp; <A HREF="http://www.electronista.com/articles/10/11/18/next.ipad.to.scale.in.february/">Next-gen iPad ramping up in February, suppliers named</A></DIV><DIV CLASS="lnkr"><CITE>Desire Athow / <A HREF="http://www.itproportal.com/">ITProPortal</A>:</CITE> &nbsp; <A HREF="http://www.itproportal.com/2010/11/19/apple-ipad-2-tablet-component-suppliers-point-q1-2011-launch/">Apple iPad 2 Tablet Component Suppliers Point To Q1 2011 Launch</A></DIV><DIV CLASS="lnkr"><CITE>James / <A HREF="http://www.phonesreview.co.uk/">Phones Review</A>:</CITE> &nbsp; <A HREF="http://www.phonesreview.co.uk/2010/11/19/apple-ipad-is-much-loved-tablet/">Apple iPad is Much Loved Tablet</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.huffingtonpost.com/">The Huffington Post</A>:</CITE> &nbsp; <A HREF="http://www.huffingtonpost.com/2010/11/19/ipad-2-rumors-heat-up-new_n_785923.html">iPad 2 Rumors Heat Up: New Report Names Alleged Suppliers, Release Date</A></DIV><DIV CLASS="shr" ID="4dxr" STYLE="display:block;"><A HREF="javascript:tgd('4',true)">&raquo; All Related Discussion</A></DIV><DIV CLASS="shr" ID="4pxr" STYLE="display:none;"><A HREF="javascript:tgd('4',false)">&laquo; Hide All Related Discussion</A></DIV></DIV>
+</DIV>
+</DIV>
+<DIV CLASS="relhed"><SPAN CLASS="drhed">RELATED:</SPAN></DIV><DIV CLASS="relitems">
+<DIV CLASS="heditem" ID="101119p4" ONMOUSEOVER="nnid('4dx2')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p4#a101119p4" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s7');
+--></script>
+<CITE>Josh Ong / <A HREF="http://appleinsider.com/">AppleInsider</A>:</CITE>
+<span id="s7" pml="101119p4" spml="AJV4" bitly="bLHysE" url="http://www.appleinsider.com/articles/10/11/18/apples_ipad_2_suppliers_to_ramp_up_in_q1_2011_rumor.html" head="Apple's iPad 2 suppliers to ramp up in Q1 2011 - rumor (@beijingdou / AppleInsider)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://www.appleinsider.com/articles/10/11/18/apples_ipad_2_suppliers_to_ramp_up_in_q1_2011_rumor.html">Apple's iPad 2 suppliers to ramp up in Q1 2011 - rumor</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.appleinsider.com/articles/10/11/18/apples_ipad_2_suppliers_to_ramp_up_in_q1_2011_rumor.html');
+--></SCRIPT>
+<DIV ID="4d2"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('4dx2')" ONMOUSEOUT="cnxbe()">
+<DIV ID="4dx2" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('4',true,2)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.9to5mac.com/36549/ipad-2-production-in-full-force-q1-2011-parts-begin-shipping-in-december">9 to 5 Mac</A></SPAN>
+</DIV></DIV>
+<DIV ID="4p2" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="4px2" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('4',false,2)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Mark Gurman / <A HREF="http://www.9to5mac.com/">9 to 5 Mac</A>:</CITE> &nbsp; <A HREF="http://www.9to5mac.com/36549/ipad-2-production-in-full-force-q1-2011-parts-begin-shipping-in-december">iPad 2 production in full-force Q1 2011, parts begin shipping in December</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101118p72"></A>
+<DIV CLASS="item" ID="101118p72" ONMOUSEOVER="nnid('5dx1')">
+<A HREF="http://www.engadget.com/2010/11/18/ipads-fondue-sets-appearing-at-tj-maxx-locations-across-the-cou/"><IMG CLASS="ill" SRC="/101118/i72.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p72#a101118p72" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s8');
+--></script>
+<CITE>Joseph L. Flatley / <A HREF="http://www.engadget.com/">Engadget</A>:</CITE>
+<span id="s8" pml="101118p72" spml="AJG8" bitly="aKheZo" url="http://www.engadget.com/2010/11/18/ipads-fondue-sets-appearing-at-tj-maxx-locations-across-the-cou/" head="$399 iPads, fondue sets appearing at TJ Maxx locations across the country (@lennyflatley / Engadget)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L2"><A HREF="http://www.engadget.com/2010/11/18/ipads-fondue-sets-appearing-at-tj-maxx-locations-across-the-cou/">$399 iPads, fondue sets appearing at TJ Maxx locations across the country</A></STRONG>&nbsp; &mdash;&nbsp; Sure, we know where you guys go when you're near a strip mall and have to pick up an irregularly sized Tommy Hilfiger shirt, or when you run out of Paco Rabanne cologne before a hot date, but we definitely did a double &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.engadget.com/2010/11/18/ipads-fondue-sets-appearing-at-tj-maxx-locations-across-the-cou/');
+--></SCRIPT>
+<DIV ID="5d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('5dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="5dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('5',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://blogs.computerworld.com/17385/2010_black_friday_comes_early_apple_ipad_100_off_the_price">Computerworld</A>, <A HREF="http://gigaom.com/apple/t-j-maxx-and-marshalls-offering-cheap-ipad-scavenger-hunt/">GigaOM</A>, <A HREF="http://m.zdnet.com/blog/hardware/are-we-reading-too-much-into-the-100-off-ipads-at-tj-maxx-story/10476">ZDNet</A>, <A HREF="http://www.9to5mac.com/36584/opinion-a-399-ipad-at-tj-maxx-apple-is-going-all-out">9 to 5 Mac</A>, <A HREF="http://www.intomobile.com/2010/11/18/apple-ipad-tj-maxx-marshall/">IntoMobile</A>, <A HREF="http://www.appletell.com/apple/comment/black-friday-16gb-wifi-ipad-tj-maxx/">Appletell</A>, <A HREF="http://daringfireball.net/linked/2010/11/19/marshalls">Daring Fireball</A>, <A HREF="http://www.gearlog.com/2010/11/tj_maxx_stores_stocking_ipads.php">Gearlog</A>, <A HREF="http://www.macrumors.com/2010/11/18/t-j-maxx-offering-16-gb-wi-fi-ipads-for-399/">MacRumors</A>, <A HREF="http://www.crunchgear.com/2010/11/18/tj-maxx-selling-ipad-for-399/">CrunchGear</A>, <A HREF="http://www.tuaw.com/2010/11/19/t-j-maxx-and-marshalls-to-offer-16gb-wifi-ipad-for-399-on-blac/">TUAW</A>, <A HREF="http://pulse2.com/2010/11/19/t-j-maxx-and-marshalls-now-selling-16gb-wifi-ipads-for-399/">Pulse2</A>, <A HREF="http://www.gadgetell.com/tech/comment/tj-maxx-now-offering-the-ipad-for-a-nicely-discounted-399/">Gadgetell</A>, <A HREF="http://www.phonearena.com/news/Apple-iPad-on-a-budget---400-at-T.J.-Maxx-and-Marshalls_id14779">PhoneArena</A>, <A HREF="http://blog.laptopmag.com/tj-maxx-selling-ipad-for-399">LAPTOP Magazine</A>, <A HREF="http://www.itproportal.com/2010/11/19/us-department-store-cutting-price-apple-ipad-399/">ITProPortal</A>, <A HREF="http://www.digitaltrends.com/computing/mac-computing/tj-maxx-marshalls-discounting-ipads-to-400/">Digital Trends</A>, <A HREF="http://www.i4u.com/42721/tjmaxx-sells-39999-apple-ipad-black-friday">I4U News</A>, <A HREF="http://www.everythingicafe.com/ipads-show-up-on-the-cheap-at-tj-maxx/2010/11/18/">everythingiCafe</A>, <A HREF="http://www.tipb.com/2010/11/18/ipads-399-tj-maxx-stores/">TiPb</A>, <A HREF="http://www.teleread.com/chris-meadows/tj-maxx-selling-16gb-ipad-for-100-off/">TeleRead</A>, <A HREF="http://www.ilounge.com/index.php/news/comments/ipads-appearing-at-tj-maxx-stores-priced-at-399/">iLounge</A>, <A HREF="http://www.coveringweb.com/2010/11/tj-maxx-to-offer-ipads-for-399-for.html">Covering Web</A>, <A HREF="http://www.macdailynews.com/index.php/weblog/comments/woz_i_was_misquoted_on_android_every_appi_have_is_better_on_iphone/">MacDailyNews</A>, <A HREF="http://www.displayblog.com/2010/11/18/16gb-wifi-ipad-us399-tj-maxx/">displayblog</A> and <A HREF="http://erictric.com/2010/11/18/select-t-j-maxx-store-selling-16gb-wi-fi-ipad-for-399-99/">Erictric</A>, <SPAN CLASS="drhed">Thanks:</SPAN><A HREF="http://twitter.com/boodycw/statuses/5376886767095808">boodycw</A></SPAN>
+</DIV></DIV>
+<DIV ID="5p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="5px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('5',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Richi Jennings / <A HREF="http://computerworld.com/">Computerworld</A>:</CITE> &nbsp; <A HREF="http://blogs.computerworld.com/17385/2010_black_friday_comes_early_apple_ipad_100_off_the_price">2010 Black Friday comes early: Apple iPad $100 off the price</A></DIV><DIV CLASS="lnkr"><CITE>Darrell Etherington / <A HREF="http://gigaom.com/">GigaOM</A>:</CITE> &nbsp; <A HREF="http://gigaom.com/apple/t-j-maxx-and-marshalls-offering-cheap-ipad-scavenger-hunt/">T.J. Maxx and Marshalls Offering Cheap iPad Scavenger Hunt</A></DIV><DIV CLASS="lnkr"><CITE>Adrian Kingsley-Hughes / <A HREF="http://www.zdnet.com/">ZDNet</A>:</CITE> &nbsp; <A HREF="http://m.zdnet.com/blog/hardware/are-we-reading-too-much-into-the-100-off-ipads-at-tj-maxx-story/10476">Are we reading too much into the &lsquo;$100 off iPads at TJ Maxx&rsquo; story?</A></DIV><DIV CLASS="lnkr"><CITE>Seth Weintraub / <A HREF="http://www.9to5mac.com/">9 to 5 Mac</A>:</CITE> &nbsp; <A HREF="http://www.9to5mac.com/36584/opinion-a-399-ipad-at-tj-maxx-apple-is-going-all-out">Opinion: A $399 iPad at TJ Maxx? Apple is going all out</A></DIV><DIV CLASS="lnkr"><CITE>Marin Perez / <A HREF="http://www.intomobile.com/">IntoMobile</A>:</CITE> &nbsp; <A HREF="http://www.intomobile.com/2010/11/18/apple-ipad-tj-maxx-marshall/">Apple iPad costs $399 from TJ Maxx, Marshalls</A></DIV><DIV CLASS="lnkr"><CITE>Jake Gaecke / <A HREF="http://www.appletell.com/">Appletell</A>:</CITE> &nbsp; <A HREF="http://www.appletell.com/apple/comment/black-friday-16gb-wifi-ipad-tj-maxx/">Black Friday 2010: 16GB WiFi iPad for $399 at TJ Maxx</A></DIV><DIV CLASS="lnkr"><CITE>John Gruber / <A HREF="http://daringfireball.net/">Daring Fireball</A>:</CITE> &nbsp; <A HREF="http://daringfireball.net/linked/2010/11/19/marshalls">Marshalls Has Those $399 iPads, Too&nbsp; &mdash;&nbsp; MacRumors, on those $399 iPads at TJ Maxx:</A></DIV><DIV CLASS="lnkr"><CITE>Brian Heater / <A HREF="http://www.gearlog.com/">Gearlog</A>:</CITE> &nbsp; <A HREF="http://www.gearlog.com/2010/11/tj_maxx_stores_stocking_ipads.php">TJ Maxx Stores Stocking iPads</A></DIV><DIV CLASS="lnkr"><CITE>Eric Slivka / <A HREF="http://www.macrumors.com/">MacRumors</A>:</CITE> &nbsp; <A HREF="http://www.macrumors.com/2010/11/18/t-j-maxx-offering-16-gb-wi-fi-ipads-for-399/">T.J. Maxx Offering 16 GB Wi-Fi iPads for $399 [Updated: Marshalls Too]</A></DIV><DIV CLASS="lnkr"><CITE>Devin Coldewey / <A HREF="http://www.crunchgear.com/">CrunchGear</A>:</CITE> &nbsp; <A HREF="http://www.crunchgear.com/2010/11/18/tj-maxx-selling-ipad-for-399/">TJ Maxx Selling iPad For $399</A></DIV><DIV CLASS="lnkr"><CITE>Michael Grothaus / <A HREF="http://www.tuaw.com/">TUAW</A>:</CITE> &nbsp; <A HREF="http://www.tuaw.com/2010/11/19/t-j-maxx-and-marshalls-to-offer-16gb-wifi-ipad-for-399-on-blac/">T.J. Maxx and Marshalls to offer 16GB Wi-Fi iPad for $399</A></DIV><DIV CLASS="lnkr"><CITE>Amit Chowdhry / <A HREF="http://pulse2.com/">Pulse2</A>:</CITE> &nbsp; <A HREF="http://pulse2.com/2010/11/19/t-j-maxx-and-marshalls-now-selling-16gb-wifi-ipads-for-399/">T.J. Maxx and Marshalls Now Selling 16GB WiFi iPads For $399</A></DIV><DIV CLASS="lnkr"><CITE>Robert Nelson / <A HREF="http://www.gadgetell.com/">Gadgetell</A>:</CITE> &nbsp; <A HREF="http://www.gadgetell.com/tech/comment/tj-maxx-now-offering-the-ipad-for-a-nicely-discounted-399/">TJ Maxx now offering the iPad for a nicely discounted $399</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.phonearena.com/">Phone Arena</A>:</CITE> &nbsp; <A HREF="http://www.phonearena.com/news/Apple-iPad-on-a-budget---400-at-T.J.-Maxx-and-Marshalls_id14779">Apple iPad on a budget - $400 at T.J. Maxx and Marshalls</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.laptopmag.com/">LAPTOP Magazine</A>:</CITE> &nbsp; <A HREF="http://blog.laptopmag.com/tj-maxx-selling-ipad-for-399">TJ Maxx Selling iPad for $399</A></DIV><DIV CLASS="lnkr"><CITE>Desire Athow / <A HREF="http://www.itproportal.com/">ITProPortal</A>:</CITE> &nbsp; <A HREF="http://www.itproportal.com/2010/11/19/us-department-store-cutting-price-apple-ipad-399/">US Department Store Cutting Price Of Apple iPad To $399</A></DIV><DIV CLASS="lnkr"><CITE>Molly McHugh / <A HREF="http://www.digitaltrends.com/">Digital Trends</A>:</CITE> &nbsp; <A HREF="http://www.digitaltrends.com/computing/mac-computing/tj-maxx-marshalls-discounting-ipads-to-400/">TJ Maxx, Marshall's discounting iPads to $400?</A></DIV><DIV CLASS="lnkr"><CITE>Luigi Lugmayr / <A HREF="http://www.i4u.com/">I4U News</A>:</CITE> &nbsp; <A HREF="http://www.i4u.com/42721/tjmaxx-sells-39999-apple-ipad-black-friday">T.J.Maxx sells $399.99 Apple iPad on Black Friday [Update]</A></DIV><DIV CLASS="lnkr"><CITE>Tim Barribeau / <A HREF="http://www.everythingicafe.com/">everythingiCafe</A>:</CITE> &nbsp; <A HREF="http://www.everythingicafe.com/ipads-show-up-on-the-cheap-at-tj-maxx/2010/11/18/">iPads Show Up On The Cheap At TJ Maxx</A></DIV><DIV CLASS="lnkr"><CITE>Andrew Wray / <A HREF="http://www.tipb.com/">TiPb</A>:</CITE> &nbsp; <A HREF="http://www.tipb.com/2010/11/18/ipads-399-tj-maxx-stores/">iPads going for $399 at TJ Maxx stores</A></DIV><DIV CLASS="lnkr"><CITE>Chris Meadows / <A HREF="http://www.teleread.com/">TeleRead</A>:</CITE> &nbsp; <A HREF="http://www.teleread.com/chris-meadows/tj-maxx-selling-16gb-ipad-for-100-off/">TJ Maxx selling 16GB iPad for $100 off</A></DIV><DIV CLASS="lnkr"><CITE>Charles Starrett / <A HREF="http://www.ilounge.com/">iLounge</A>:</CITE> &nbsp; <A HREF="http://www.ilounge.com/index.php/news/comments/ipads-appearing-at-tj-maxx-stores-priced-at-399/">iPads appearing at TJ Maxx stores priced at $399</A></DIV><DIV CLASS="lnkr"><CITE>Ahmed Omar / <A HREF="http://www.coveringweb.com/">Covering Web</A>:</CITE> &nbsp; <A HREF="http://www.coveringweb.com/2010/11/tj-maxx-to-offer-ipads-for-399-for.html">TJ Maxx to Offer iPads for $399 for Black Friday</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.macdailynews.com/">MacDailyNews</A>:</CITE> &nbsp; <A HREF="http://www.macdailynews.com/index.php/weblog/comments/woz_i_was_misquoted_on_android_every_appi_have_is_better_on_iphone/">Woz: I was misquoted on Android; 'Almost every app that I have &hellip; </A></DIV><DIV CLASS="lnkr"><CITE>Jin / <A HREF="http://www.displayblog.com/">displayblog</A>:</CITE> &nbsp; <A HREF="http://www.displayblog.com/2010/11/18/16gb-wifi-ipad-us399-tj-maxx/">16GB WiFi iPad: US$399 @ TJ Maxx</A></DIV><DIV CLASS="lnkr"><CITE>Bertrand Vasquez / <A HREF="http://erictric.com/">Erictric</A>:</CITE> &nbsp; <A HREF="http://erictric.com/2010/11/18/select-t-j-maxx-store-selling-16gb-wi-fi-ipad-for-399-99/">Select T.J. Maxx Store Selling 16GB Wi-Fi iPad for $399.99</A></DIV><DIV CLASS="lnkr"><SPAN CLASS="drhed">Thanks:</SPAN><A HREF="http://twitter.com/boodycw/statuses/5376886767095808">boodycw</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101118p64"></A>
+<DIV CLASS="item" ID="101118p64" ONMOUSEOVER="nnid('6dx1')">
+<A HREF="http://news.cnet.com/8301-30685_3-20023199-264.html"><IMG CLASS="ill" SRC="/101118/i64.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p64#a101118p64" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s9');
+--></script>
+<CITE>Stephen Shankland / <A HREF="http://news.cnet.com/">CNET News</A>:</CITE>
+<span id="s9" pml="101118p64" spml="AJG0" bitly="crRwut" url="http://news.cnet.com/8301-30685_3-20023199-264.html" head="Angry Birds spotlights Android fragmentation (@stshank / CNET News)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L2"><A HREF="http://news.cnet.com/8301-30685_3-20023199-264.html">Angry Birds spotlights Android fragmentation</A></STRONG>&nbsp; &mdash;&nbsp; The good news for Android is that it's flexible enough to reach many corners of the smartphone market.&nbsp; The bad news is that this can mean headaches for programmers&mdash;as the top-ranked game Angry Birds illustrated today.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://news.cnet.com/8301-30685_3-20023199-264.html');
+--></SCRIPT>
+<DIV ID="6d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('6dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="6dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('6',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.pcworld.com/article/211152/">PC World</A>, <A HREF="http://www.theregister.co.uk/2010/11/19/android_fragmentation/">The Register</A>, <A HREF="http://www.zdnet.com/blog/hardware/angry-birds-ruffled-over-android-fragmentation/10468">Hardware 2.0 Blog</A>, <A HREF="http://www.geek.com/articles/mobile/angry-birds-creator-rovio-addresses-android-problems-20101119/">Geek.com</A>, <A HREF="http://pulse2.com/2010/11/19/rovio-mobile-developing-new-version-of-angry-birds-for-lower-end-android-phones/">Pulse2</A>, <A HREF="http://www.slashgear.com/angry-birds-devs-admit-lightweight-version-in-works-for-underpowered-android-phones-19115044/">SlashGear</A>, <A HREF="http://www.guardian.co.uk/technology/blog/2010/nov/19/technology-links-newsbucket">Guardian</A>, <A HREF="http://www.electronista.com/articles/10/11/19/more.evidence.of.android.platform.fragmentation/">Electronista</A>, <A HREF="http://www.gamasutra.com/view/news/31618/Mobile_Hit_Angry_Birds_Runs_Into_Android_Issues.php">Gamasutra</A>, <A HREF="http://pocketnow.com/android/angry-birds-lightweight-coming-bonus-level-trojan-detailed">pocketnow.com</A>, <A HREF="http://www.gadgetell.com/tech/comment/angry-birds-update-proves-that-the-android-os-should-emulate-ios/">Gadgetell</A>, <A HREF="http://www.phonearena.com/news/Angry-Birds-Lite-coming-for-lesser-specd-Android-phones_id14766">PhoneArena</A>, <A HREF="http://www.digitaltrends.com/mobile/smurfs-village-takes-angry-birds-topspot-for-now/">Digital Trends</A>, <A HREF="http://gizmodo.com/5693428/">Gizmodo</A>, <A HREF="http://gigaom.com/mobile/angry-birds-coming-to-low-end-android-phones/">GigaOM</A> and <A HREF="http://news.softpedia.com/news/Angry-Birds-on-More-Android-Devices-Arrives-in-a-Lightweight-Flavor-Too-167363.shtml">Softpedia News</A></SPAN>
+</DIV></DIV>
+<DIV ID="6p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="6px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('6',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Daniel Ionescu / <A HREF="http://www.pcworld.com/">PC World</A>:</CITE> &nbsp; <A HREF="http://www.pcworld.com/article/211152/">Angry Birds Devs Angry At Android Fragmentation</A></DIV><DIV CLASS="lnkr"><CITE>Bill Ray / <A HREF="http://www.theregister.co.uk/">The Register</A>:</CITE> &nbsp; <A HREF="http://www.theregister.co.uk/2010/11/19/android_fragmentation/">Angry Birds struggle to take on Androids</A></DIV><DIV CLASS="lnkr"><CITE>Adrian Kingsley-Hughes / <A HREF="http://www.zdnet.com/blog/hardware">Hardware 2.0 Blog</A>:</CITE> &nbsp; <A HREF="http://www.zdnet.com/blog/hardware/angry-birds-ruffled-over-android-fragmentation/10468">Angry Birds ruffled over Android fragmentation</A></DIV><DIV CLASS="lnkr"><CITE>Russell Holly / <A HREF="http://www.geek.com/">Geek.com</A>:</CITE> &nbsp; <A HREF="http://www.geek.com/articles/mobile/angry-birds-creator-rovio-addresses-android-problems-20101119/">Angry Birds creator Rovio addresses Android problems</A></DIV><DIV CLASS="lnkr"><CITE>Amit Chowdhry / <A HREF="http://pulse2.com/">Pulse2</A>:</CITE> &nbsp; <A HREF="http://pulse2.com/2010/11/19/rovio-mobile-developing-new-version-of-angry-birds-for-lower-end-android-phones/">Rovio Mobile Developing New Version Of Angry Birds For Lower-End Android Phones</A></DIV><DIV CLASS="lnkr"><CITE>Chris Davies / <A HREF="http://www.slashgear.com/">SlashGear</A>:</CITE> &nbsp; <A HREF="http://www.slashgear.com/angry-birds-devs-admit-lightweight-version-in-works-for-underpowered-android-phones-19115044/">Angry Birds devs admit lightweight version in works for underpowered Android phones</A></DIV><DIV CLASS="lnkr"><CITE>Charles Arthur / <A HREF="http://www.guardian.co.uk/technology/blog">Guardian</A>:</CITE> &nbsp; <A HREF="http://www.guardian.co.uk/technology/blog/2010/nov/19/technology-links-newsbucket">The Technology newsbucket: smartphone wars, Google TV's chaos &hellip; </A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.electronista.com/">Electronista</A>:</CITE> &nbsp; <A HREF="http://www.electronista.com/articles/10/11/19/more.evidence.of.android.platform.fragmentation/">Rovio: lightweight Angry Birds for slow Android mobiles</A></DIV><DIV CLASS="lnkr"><CITE>Kris Graft / <A HREF="http://www.gamasutra.com/">Gamasutra</A>:</CITE> &nbsp; <A HREF="http://www.gamasutra.com/view/news/31618/Mobile_Hit_Angry_Birds_Runs_Into_Android_Issues.php">Mobile Hit Angry Birds Runs Into Android Issues</A></DIV><DIV CLASS="lnkr"><CITE>Evan Blass / <A HREF="http://pocketnow.com/">pocketnow.com</A>:</CITE> &nbsp; <A HREF="http://pocketnow.com/android/angry-birds-lightweight-coming-bonus-level-trojan-detailed">Angry Birds Lightweight Coming; &lsquo;Bonus Level&rsquo; Trojan Detailed</A></DIV><DIV CLASS="lnkr"><CITE>Arnold Zafra / <A HREF="http://www.gadgetell.com/">Gadgetell</A>:</CITE> &nbsp; <A HREF="http://www.gadgetell.com/tech/comment/angry-birds-update-proves-that-the-android-os-should-emulate-ios/">Angry Birds update proves that the Android OS should emulate iOS</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.phonearena.com/">Phone Arena</A>:</CITE> &nbsp; <A HREF="http://www.phonearena.com/news/Angry-Birds-Lite-coming-for-lesser-specd-Android-phones_id14766">Angry Birds Lite coming for lesser spec'd Android phones</A></DIV><DIV CLASS="lnkr"><CITE>Molly McHugh / <A HREF="http://www.digitaltrends.com/">Digital Trends</A>:</CITE> &nbsp; <A HREF="http://www.digitaltrends.com/mobile/smurfs-village-takes-angry-birds-topspot-for-now/">Smurf's Village swipes Angry Birds' top spot, for now</A></DIV><DIV CLASS="lnkr"><CITE>Matt Buchanan / <A HREF="http://gizmodo.com/">Gizmodo</A>:</CITE> &nbsp; <A HREF="http://gizmodo.com/5693428/">Angry Birds Shows What Android Fragmentation Means</A></DIV><DIV CLASS="lnkr"><CITE>James Kendrick / <A HREF="http://gigaom.com/">GigaOM</A>:</CITE> &nbsp; <A HREF="http://gigaom.com/mobile/angry-birds-coming-to-low-end-android-phones/">Angry Birds Coming to Low-End Android Phones</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.softpedia.com/">Softpedia News</A>:</CITE> &nbsp; <A HREF="http://news.softpedia.com/news/Angry-Birds-on-More-Android-Devices-Arrives-in-a-Lightweight-Flavor-Too-167363.shtml">Angry Birds on More Android Devices, Arrives in a Lightweight Flavor Too</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p6"></A>
+<DIV CLASS="item" ID="101119p6" ONMOUSEOVER="nnid('7dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p6#a101119p6" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s10');
+--></script>
+<CITE>Kelly Riddell / <A HREF="http://www.bloomberg.com/news/index.html">Bloomberg</A>:</CITE>
+<span id="s10" pml="101119p6" spml="AJV6" bitly="d9iR31" url="http://www.bloomberg.com/news/2010-11-19/cox-communications-takes-on-at-t-verizon-with-mobile-offering.html" head="Cox Communications Takes On AT&T, Verizon With Mobile Offering (Kelly Riddell / Bloomberg)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.bloomberg.com/news/2010-11-19/cox-communications-takes-on-at-t-verizon-with-mobile-offering.html">Cox Communications Takes On AT&amp;T, Verizon With Mobile Offering</A></STRONG>&nbsp; &mdash;&nbsp; Cox Communications Inc. is becoming the first U.S. cable company to offer a mobile-phone service as it looks to challenge incumbents AT&amp;T Inc. and Verizon Wireless by bundling wireless handsets with Web and TV.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.bloomberg.com/news/2010-11-19/cox-communications-takes-on-at-t-verizon-with-mobile-offering.html');
+--></SCRIPT>
+<DIV ID="7d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('7dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="7dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('7',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://gigaom.com/2010/11/19/cox-wireless-launch/">GigaOM</A>, <A HREF="http://news.cnet.com/8301-1035_3-20023356-94.html">CNET News</A>, <A HREF="http://www.engadget.com/2010/11/19/cox-enters-wireless-market-with-unbelievably-fair-contracts-ri/">Engadget</A>, <A HREF="http://www.phonedog.com/2010/11/19/cox-launches-its-own-wireless-service-with-unbelievably-fair-plans/">PhoneDog.com</A>, <A HREF="http://phandroid.com/2010/11/19/cox-wireless-provides-new-carrier-option-with-two-android-phones-to-sell/">Android Phone Fans</A>, <A HREF="http://tech.fortune.cnn.com/2010/11/19/cox-to-become-sprint-mvno-with-android-smartphones/">Fortune</A>, <A HREF="http://www.electronista.com/articles/10/11/19/cox.cellphone.service.finally.live/">Electronista</A>, <A HREF="http://news.yahoo.com/s/ap/20101119/ap_on_hi_te/us_tec_cox_wireless">Associated Press</A>, <A HREF="http://www.usatoday.com/tech/wireless/2010-11-19-coxphone19_ST_N.htm">USA Today</A>, <A HREF="http://www.digitalsociety.org/2010/11/genachowski-pushing-ahead-with-net-neutrality-during-lame-duck/">Digital Society</A> and <A HREF="http://www.reuters.com/article/idUSN1810481720101119">Reuters</A></SPAN>
+</DIV></DIV>
+<DIV ID="7p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="7px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('7',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Kevin C. Tofel / <A HREF="http://gigaom.com/">GigaOM</A>:</CITE> &nbsp; <A HREF="http://gigaom.com/2010/11/19/cox-wireless-launch/">Cox Launches Consumer-Friendly Wireless</A></DIV><DIV CLASS="lnkr"><CITE>Lance Whitney / <A HREF="http://news.cnet.com/">CNET News</A>:</CITE> &nbsp; <A HREF="http://news.cnet.com/8301-1035_3-20023356-94.html">Cox touts refunds in wireless launch</A></DIV><DIV CLASS="lnkr"><CITE>Vlad Savov / <A HREF="http://www.engadget.com/">Engadget</A>:</CITE> &nbsp; <A HREF="http://www.engadget.com/2010/11/19/cox-enters-wireless-market-with-unbelievably-fair-contracts-ri/">Cox enters wireless market with &lsquo;Unbelievably Fair&rsquo; contracts</A></DIV><DIV CLASS="lnkr"><CITE>Alex Wagner / <A HREF="http://www.phonedog.com/blog/default.aspx">PhoneDog.com</A>:</CITE> &nbsp; <A HREF="http://www.phonedog.com/2010/11/19/cox-launches-its-own-wireless-service-with-unbelievably-fair-plans/">Cox launches its own wireless service with &lsquo;Unbelievably Fair&rsquo; plans</A></DIV><DIV CLASS="lnkr"><CITE>Quentyn Kennemer / <A HREF="http://phandroid.com/">Android Phone Fans</A>:</CITE> &nbsp; <A HREF="http://phandroid.com/2010/11/19/cox-wireless-provides-new-carrier-option-with-two-android-phones-to-sell/">Cox Wireless Provides New Carrier Option with two Android Phones to Sell</A></DIV><DIV CLASS="lnkr"><CITE>Seth Weintraub / <A HREF="http://www.fortune.com/">Fortune</A>:</CITE> &nbsp; <A HREF="http://tech.fortune.cnn.com/2010/11/19/cox-to-become-sprint-mvno-with-android-smartphones/">Cox to become Sprint MVNO with Android Smartphones</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.electronista.com/">Electronista</A>:</CITE> &nbsp; <A HREF="http://www.electronista.com/articles/10/11/19/cox.cellphone.service.finally.live/">Cox starts up cellphone service, gives cash for unused time</A></DIV><DIV CLASS="lnkr"><CITE>Peter Svensson / <A HREF="http://news.yahoo.com/i/528">Associated Press</A>:</CITE> &nbsp; <A HREF="http://news.yahoo.com/s/ap/20101119/ap_on_hi_te/us_tec_cox_wireless">Cable company Cox launches cell service</A></DIV><DIV CLASS="lnkr"><CITE>David Lieberman / <A HREF="http://www.usatoday.com/">USA Today</A>:</CITE> &nbsp; <A HREF="http://www.usatoday.com/tech/wireless/2010-11-19-coxphone19_ST_N.htm">Cox Communications plans wireless phone service</A></DIV><DIV CLASS="lnkr"><CITE>George Ou / <A HREF="http://www.digitalsociety.org/">Digital Society</A>:</CITE> &nbsp; <A HREF="http://www.digitalsociety.org/2010/11/genachowski-pushing-ahead-with-net-neutrality-during-lame-duck/">Genachowski pushing ahead with Net Neutrality during lame duck</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.yahoo.com/i/578">Reuters</A>:</CITE> &nbsp; <A HREF="http://www.reuters.com/article/idUSN1810481720101119">Cox kicks of mobile service with money back offer</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p1"></A>
+<DIV CLASS="item" ID="101119p1" ONMOUSEOVER="nnid('8dx1')">
+<A HREF="http://techcrunch.com/2010/11/18/twitter-people/"><IMG CLASS="ill" SRC="/101119/i1.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p1#a101119p1" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s11');
+--></script>
+<CITE>MG Siegler / <A HREF="http://techcrunch.com/">TechCrunch</A>:</CITE>
+<span id="s11" pml="101119p1" spml="AJV1" bitly="8ZNSvq" url="http://techcrunch.com/2010/11/18/twitter-people/" head="Twitter Testing A New "People" Tab: All Your Social Graph Steroids In One Place (@parislemon /..." class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://techcrunch.com/2010/11/18/twitter-people/">Twitter Testing A New &ldquo;People&rdquo; Tab: All Your Social Graph Steroids In One Place</A></STRONG>&nbsp; &mdash;&nbsp; Since the launch of New Twitter in September, things have been pretty quiet on the new feature front.&nbsp; Yes, they're testing out a new analytics product, but in terms of features that the majority of end users will use &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://techcrunch.com/2010/11/18/twitter-people/');
+--></SCRIPT>
+<DIV ID="8d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('8dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="8dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('8',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://mashable.com/2010/11/19/twitter-people-2/">Mashable!</A>, <A HREF="http://searchengineland.com/twitter-kinda-launches-a-directory-56423">Search Engine Land</A>, <A HREF="http://siliconangle.com/blog/2010/11/19/follow-twitter-upgrades-%E2%80%9Cpeople%E2%80%9D-to-spur-more-interactions/">SiliconANGLE</A>, <A HREF="http://techie-buzz.com/social-networking/twitter-ties-up-with-linkedin-wefollow-bing-for-directory-services.html">Techie Buzz</A>, <A HREF="http://www.trendslate.com/2010/11/19/twitter-launches-people-directory/">TrendSlate</A> and <A HREF="http://thenextweb.com/socialmedia/2010/11/19/call-it-people-or-directory-twitter-is-recommending-people-in-a-whole-new-way/">The Next Web</A></SPAN>
+</DIV></DIV>
+<DIV ID="8p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="8px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('8',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Stan Schroeder / <A HREF="http://mashable.com/">Mashable!</A>:</CITE> &nbsp; <A HREF="http://mashable.com/2010/11/19/twitter-people-2/">Twitter Helps You Find More Friends With New &ldquo;People&rdquo; Tab</A></DIV><DIV CLASS="lnkr"><CITE>Matt McGee / <A HREF="http://searchengineland.com/">Search Engine Land</A>:</CITE> &nbsp; <A HREF="http://searchengineland.com/twitter-kinda-launches-a-directory-56423">Twitter (Kinda) Launches A Directory</A></DIV><DIV CLASS="lnkr"><CITE>Cherr Aira Quintana / <A HREF="http://siliconangle.com/">SiliconANGLE</A>:</CITE> &nbsp; <A HREF="http://siliconangle.com/blog/2010/11/19/follow-twitter-upgrades-%E2%80%9Cpeople%E2%80%9D-to-spur-more-interactions/">Follow Twitter Upgrades: &ldquo;People&rdquo; To Spur More Interactions</A></DIV><DIV CLASS="lnkr"><CITE>Keith Dsouza / <A HREF="http://techie-buzz.com/">Techie Buzz</A>:</CITE> &nbsp; <A HREF="http://techie-buzz.com/social-networking/twitter-ties-up-with-linkedin-wefollow-bing-for-directory-services.html">Twitter Ties Up With LinkedIn, WeFollow, Bing For Directory Services</A></DIV><DIV CLASS="lnkr"><CITE>Eric Fader / <A HREF="http://www.trendslate.com/">TrendSlate</A>:</CITE> &nbsp; <A HREF="http://www.trendslate.com/2010/11/19/twitter-launches-people-directory/">Twitter Launches People Directory</A></DIV><DIV CLASS="lnkr"><CITE>Tris Hussey / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/socialmedia/2010/11/19/call-it-people-or-directory-twitter-is-recommending-people-in-a-whole-new-way/">Call It People or Directory: Twitter is Recommending People in a Whole New Way</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p7"></A>
+<DIV CLASS="item" ID="101119p7" ONMOUSEOVER="nnid('9dx1')">
+<A HREF="http://www.wired.com/threatlevel/2010/11/hacker-border-search/"><IMG CLASS="ill" SRC="/101119/i7.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p7#a101119p7" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s12');
+--></script>
+<CITE>Kim Zetter / <A HREF="http://www.wired.com/threatlevel">Threat Level</A>:</CITE>
+<span id="s12" pml="101119p7" spml="AJV7" bitly="bkp3bD" url="http://www.wired.com/threatlevel/2010/11/hacker-border-search/" head="Another Hacker's Laptop, Cell Phones Searched at Border (@kimzetter / Threat Level)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.wired.com/threatlevel/2010/11/hacker-border-search/">Another Hacker's Laptop, Cell Phones Searched at Border</A></STRONG>&nbsp; &mdash;&nbsp; A well-known and respected computer security researcher was detained for several hours Wednesday night by border agents who searched his laptop and cell phones before returning them to him.&nbsp; &mdash;&nbsp; The researcher, who goes &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.wired.com/threatlevel/2010/11/hacker-border-search/');
+--></SCRIPT>
+<DIV ID="9d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('9dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="9dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('9',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://news.cnet.com/8301-27080_3-20023341-245.html">CNET News</A>, <A HREF="http://www.net-security.org/secworld.php?id=10187">Help Net Security</A> and <A HREF="http://www.boingboing.net/2010/11/18/why-are-the-feds-sur.html">Boing Boing</A>, <SPAN CLASS="drhed">Thanks:</SPAN><A HREF="http://twitter.com/hornokplease/statuses/5496400016052224">hornokplease</A></SPAN>
+</DIV></DIV>
+<DIV ID="9p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="9px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('9',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Elinor Mills / <A HREF="http://news.cnet.com/">CNET News</A>:</CITE> &nbsp; <A HREF="http://news.cnet.com/8301-27080_3-20023341-245.html">Security researcher: I keep getting detained by feds</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.net-security.org/">Help Net Security</A>:</CITE> &nbsp; <A HREF="http://www.net-security.org/secworld.php?id=10187">Whitehat hacker's laptop, cellphones seized and searched</A></DIV><DIV CLASS="lnkr"><CITE>Xeni Jardin / <A HREF="http://www.boingboing.net/">Boing Boing</A>:</CITE> &nbsp; <A HREF="http://www.boingboing.net/2010/11/18/why-are-the-feds-sur.html">Why are the feds surveilling and repeatedly detaining computer &hellip; </A></DIV><DIV CLASS="lnkr"><SPAN CLASS="drhed">Thanks:</SPAN><A HREF="http://twitter.com/hornokplease/statuses/5496400016052224">hornokplease</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p9"></A>
+<DIV CLASS="item" ID="101119p9" ONMOUSEOVER="nnid('10dx1')">
+<A HREF="http://www.9to5mac.com/36541/mac-store-opening-soon-apple-implores-developers-to-submit-their-apps"><IMG CLASS="ill" SRC="/101119/i9.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p9#a101119p9" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s13');
+--></script>
+<CITE>Seth Weintraub / <A HREF="http://www.9to5mac.com/">9 to 5 Mac</A>:</CITE>
+<span id="s13" pml="101119p9" spml="AJV9" bitly="91ju7Y" url="http://www.9to5mac.com/36541/mac-store-opening-soon-apple-implores-developers-to-submit-their-apps" head="Mac App Store opening soon, Apple implores developers to submit their apps (@llsethj / 9 to 5 Mac)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.9to5mac.com/36541/mac-store-opening-soon-apple-implores-developers-to-submit-their-apps">Mac App Store opening soon, Apple implores developers to submit their apps</A></STRONG>&nbsp; &mdash;&nbsp; Apple sent out an email this evening telling Mac developers to submit their Mac &lsquo;apps&rsquo; for inclsion in the opening of the store which should happen pretty soon.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.9to5mac.com/36541/mac-store-opening-soon-apple-implores-developers-to-submit-their-apps');
+--></SCRIPT>
+<DIV ID="10d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('10dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="10dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('10',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.fastcompany.com/1703936/ifive-nz-miners-trapped-apple-calls-up-mac-apps-mits-corner-camera-fiji-water-gets-political">Fast Company</A>, <A HREF="http://news.softpedia.com/news/Apple-The-Mac-App-Store-Will-Be-Opening-Soon-167607.shtml">Softpedia News</A>, <A HREF="http://www.slashgear.com/apple-mac-app-store-reminder-pushes-for-dev-submissions-19115107/">SlashGear</A> and <A HREF="http://thenextweb.com/apple/2010/11/19/apple-please-please-submit-your-apps-to-to-the-mac-app-store/">The Next Web</A></SPAN>
+</DIV></DIV>
+<DIV ID="10p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="10px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('10',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Addy Dugdale / <A HREF="http://www.fastcompany.com/">Fast Company</A>:</CITE> &nbsp; <A HREF="http://www.fastcompany.com/1703936/ifive-nz-miners-trapped-apple-calls-up-mac-apps-mits-corner-camera-fiji-water-gets-political">iFive: Twitter's People Tab, Apple Calls Up Mac Apps, MIT's Corner &hellip; </A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.softpedia.com/">Softpedia News</A>:</CITE> &nbsp; <A HREF="http://news.softpedia.com/news/Apple-The-Mac-App-Store-Will-Be-Opening-Soon-167607.shtml">Apple: &lsquo;The Mac App Store Will Be Opening Soon&rsquo;</A></DIV><DIV CLASS="lnkr"><CITE>Chris Davies / <A HREF="http://www.slashgear.com/">SlashGear</A>:</CITE> &nbsp; <A HREF="http://www.slashgear.com/apple-mac-app-store-reminder-pushes-for-dev-submissions-19115107/">Apple Mac App Store reminder pushes for dev submissions</A></DIV><DIV CLASS="lnkr"><CITE>Fraser Smith / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/apple/2010/11/19/apple-please-please-submit-your-apps-to-to-the-mac-app-store/">Apple: Please, please submit your apps to to the Mac App Store.</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p26"></A>
+<DIV CLASS="item" ID="101119p26" ONMOUSEOVER="nnid('11dx1')">
+<A HREF="http://digitaldaily.allthingsd.com/20101119/apple-developing-cdma-gsm-world-ipad/"><IMG CLASS="ill" SRC="/101119/i26.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p26#a101119p26" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s14');
+--></script>
+<CITE>John Paczkowski / <A HREF="http://digitaldaily.allthingsd.com/">Digital Daily</A>:</CITE><SPAN CLASS="new">NEW!</SPAN>
+<span id="s14" pml="101119p26" spml="AJVP" bitly="bC8XMY" url="http://digitaldaily.allthingsd.com/20101119/apple-developing-cdma-gsm-world-ipad/" head="Apple Developing CDMA-GSM 'World iPad'? (@johnpaczkowski / Digital Daily)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://digitaldaily.allthingsd.com/20101119/apple-developing-cdma-gsm-world-ipad/">Apple Developing CDMA-GSM &lsquo;World iPad&rsquo;?</A></STRONG>&nbsp; &mdash;&nbsp; Here's an interesting bit of speculation from Wedge Partners analyst Brian Blair, whose recent Qualcomm channel checks may reveal something about Apple's next generation iPad.&nbsp; According to Blair, Apple is developing a &ldquo;World iPad&rdquo; based on one of Qualcomm's multimode CDMA-GSM chips.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://digitaldaily.allthingsd.com/20101119/apple-developing-cdma-gsm-world-ipad/');
+--></SCRIPT>
+<DIV ID="11d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('11dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="11dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('11',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.macrumors.com/2010/11/19/production-of-next-generation-ipad-set-to-ramp-in-february-world-mode-cellular-data-access/">MacRumors</A>, <A HREF="http://blogs.computerworld.com/17384/what_we_think_we_know_about_ipad_2_0">Computerworld</A>, <A HREF="http://www.appleinsider.com/articles/10/11/19/apples_next_gen_ipad_rumored_with_world_mode_gsm_cdma_radio.html">AppleInsider</A>, <A HREF="http://www.businessinsider.com/ipad-2-features-2010-11">SAI</A>, <A HREF="http://technolog.msnbc.msn.com/_news/2010/11/19/5494676-thinner-more-global-ipad-in-the-works">msnbc.com</A>, <A HREF="http://thenextweb.com/apple/2010/11/19/is-apple-about-to-unleash-a-world-edition-ipad/">The Next Web</A>, <A HREF="http://www.slashgear.com/world-ipad-with-multi-mode-gsmcdma-modem-tipped-for-2011-19115082/">SlashGear</A>, <A HREF="http://www.intomobile.com/2010/11/19/apple-ipad-2-gsm-cdma-production-q1-2011/">IntoMobile</A>, <A HREF="http://www.everythingicafe.com/analyst-eightball-apple-creating-unibody-world-ipad/2010/11/19/">everythingiCafe</A>, <A HREF="http://www.electronista.com/articles/10/11/19/analyst.claims.to.know.new.3g.ipad.is.dual.mode/">Electronista</A>, <A HREF="http://www.macdailynews.com/index.php/weblog/comments/analyst_apples_next-gen_ipad_to_feature_world_mode_gsm-cdma_chip/">MacDailyNews</A>, <A HREF="http://www.loopinsight.com/2010/11/19/report-apple-building-a-cdma-gsm-world-ipad/">The Loop</A> and <A HREF="http://www.phonesreview.co.uk/2010/11/19/apple-ipad-2-on-way-world-version-coming-2011/">Phones Review</A></SPAN>
+</DIV></DIV>
+<DIV ID="11p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="11px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('11',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Eric Slivka / <A HREF="http://www.macrumors.com/">MacRumors</A>:</CITE> &nbsp; <A HREF="http://www.macrumors.com/2010/11/19/production-of-next-generation-ipad-set-to-ramp-in-february-world-mode-cellular-data-access/">Production of Next-Generation iPad Set to Ramp in February?</A></DIV><DIV CLASS="lnkr"><CITE>Jonny Evans / <A HREF="http://computerworld.com/">Computerworld</A>:</CITE> &nbsp; <A HREF="http://blogs.computerworld.com/17384/what_we_think_we_know_about_ipad_2_0">What we think we know about iPad 2.0&nbsp; &mdash;&nbsp; Only this morning declared &hellip; </A></DIV><DIV CLASS="lnkr"><CITE>Sam Oliver / <A HREF="http://appleinsider.com/">AppleInsider</A>:</CITE> &nbsp; <A HREF="http://www.appleinsider.com/articles/10/11/19/apples_next_gen_ipad_rumored_with_world_mode_gsm_cdma_radio.html">Apple's next-gen iPad rumored with world mode GSM-CDMA radio</A></DIV><DIV CLASS="lnkr"><CITE>Jay Yarow / <A HREF="http://www.businessinsider.com/sai">SAI: Silicon Alley Insider</A>:</CITE> &nbsp; <A HREF="http://www.businessinsider.com/ipad-2-features-2010-11">iPad 2 Rumors: Front Facing Camera, CDMA-GSM Chip, Thinner Design</A></DIV><DIV CLASS="lnkr"><CITE>Suzanne Choney / <A HREF="http://www.msnbc.msn.com/">msnbc.com</A>:</CITE> &nbsp; <A HREF="http://technolog.msnbc.msn.com/_news/2010/11/19/5494676-thinner-more-global-ipad-in-the-works">Thinner, more global iPad in the works?</A></DIV><DIV CLASS="lnkr"><CITE>Brad McCarty / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/apple/2010/11/19/is-apple-about-to-unleash-a-world-edition-ipad/">Is Apple about to unleash a World Edition iPad?</A></DIV><DIV CLASS="lnkr"><CITE>Chris Davies / <A HREF="http://www.slashgear.com/">SlashGear</A>:</CITE> &nbsp; <A HREF="http://www.slashgear.com/world-ipad-with-multi-mode-gsmcdma-modem-tipped-for-2011-19115082/">World iPad with multi-mode GSM/CDMA modem tipped for 2011</A></DIV><DIV CLASS="lnkr"><CITE>Kelly Hodgkins / <A HREF="http://www.intomobile.com/">IntoMobile</A>:</CITE> &nbsp; <A HREF="http://www.intomobile.com/2010/11/19/apple-ipad-2-gsm-cdma-production-q1-2011/">Apple iPad 2 to include GSM/CDMA radio, volume production in Q1 2011</A></DIV><DIV CLASS="lnkr"><CITE>Tim Barribeau / <A HREF="http://www.everythingicafe.com/">everythingiCafe</A>:</CITE> &nbsp; <A HREF="http://www.everythingicafe.com/analyst-eightball-apple-creating-unibody-world-ipad/2010/11/19/">Analyst Eightball: Apple Creating Unibody World iPad</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.electronista.com/">Electronista</A>:</CITE> &nbsp; <A HREF="http://www.electronista.com/articles/10/11/19/analyst.claims.to.know.new.3g.ipad.is.dual.mode/">Analyst says next 3G iPad to have dual-mode EVDO, HSPA chip</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.macdailynews.com/">MacDailyNews</A>:</CITE> &nbsp; <A HREF="http://www.macdailynews.com/index.php/weblog/comments/analyst_apples_next-gen_ipad_to_feature_world_mode_gsm-cdma_chip/">Analyst: Apple's next-gen iPad to feature world mode GSM-CDMA chip</A></DIV><DIV CLASS="lnkr"><CITE>Jim Dalrymple / <A HREF="http://www.loopinsight.com/">The Loop</A>:</CITE> &nbsp; <A HREF="http://www.loopinsight.com/2010/11/19/report-apple-building-a-cdma-gsm-world-ipad/">Report: Apple building a CDMA-GSM &lsquo;World iPad&rsquo;</A></DIV><DIV CLASS="lnkr"><CITE>James / <A HREF="http://www.phonesreview.co.uk/">Phones Review</A>:</CITE> &nbsp; <A HREF="http://www.phonesreview.co.uk/2010/11/19/apple-ipad-2-on-way-world-version-coming-2011/">Apple iPad 2 On Way, World Version Coming 2011?</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p3"></A>
+<DIV CLASS="item" ID="101119p3" ONMOUSEOVER="nnid('12dx1')">
+<A HREF="http://www.readwriteweb.com/archives/meet_the_firehose_seven_thousand_times_bigger_than.php"><IMG CLASS="ill" SRC="/101119/i3.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p3#a101119p3" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s15');
+--></script>
+<CITE>Marshall Kirkpatrick / <A HREF="http://www.readwriteweb.com/">ReadWriteWeb</A>:</CITE>
+<span id="s15" pml="101119p3" spml="AJV3" bitly="aaNKB7" url="http://www.readwriteweb.com/archives/meet_the_firehose_seven_thousand_times_bigger_than.php" head="Meet the Firehose Seven Thousand Times Bigger Than Twitter's (@marshallk / ReadWriteWeb)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.readwriteweb.com/archives/meet_the_firehose_seven_thousand_times_bigger_than.php">Meet the Firehose Seven Thousand Times Bigger Than Twitter's</A></STRONG>&nbsp; &mdash;&nbsp; Twitter announced yesterday that for the first time, outside developers will be allowed to purchase access to 50% of all the messages that flow through its network.&nbsp; The price for half the firehose?&nbsp; $360,000 per year, payable to partner company Gnip.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.readwriteweb.com/archives/meet_the_firehose_seven_thousand_times_bigger_than.php');
+--></SCRIPT>
+<DIV ID="12d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('12dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="12dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('12',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://vator.tv/news/2010-11-18-gnip-gets-2m-to-resell-the-twitter-firehose">VatorNews</A>, <A HREF="http://venturebeat.com/2010/11/18/gnip-funding-twitter-data/">VentureBeat</A>, <A HREF="http://pjnet.org/post/2429/">PJNet</A>, <A HREF="http://www.adotas.com/2010/11/got-funds-gnip-scores-2-million-after-twitter-data-selling-deal/">Adotas</A> and <A HREF="http://blogs.reuters.com/mediafile/2010/11/18/why-is-facebook-worth-ten-twitters/">MediaFile</A></SPAN>
+</DIV></DIV>
+<DIV ID="12p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="12px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('12',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Ronny Kerr / <A HREF="http://vator.tv/news/">VatorNews</A>:</CITE> &nbsp; <A HREF="http://vator.tv/news/2010-11-18-gnip-gets-2m-to-resell-the-twitter-firehose">Gnip gets $2M to resell the Twitter firehose</A></DIV><DIV CLASS="lnkr"><CITE>Riley McDermid / <A HREF="http://venturebeat.com/">VentureBeat</A>:</CITE> &nbsp; <A HREF="http://venturebeat.com/2010/11/18/gnip-funding-twitter-data/">Gnip grabs $2M as it teams up with Twitter in new data selling deal</A></DIV><DIV CLASS="lnkr"><CITE>Leonard Witt / <A HREF="http://pjnet.org/">PJNet</A>:</CITE> &nbsp; <A HREF="http://pjnet.org/post/2429/">Search 50% of Annual Archived Tweets for Just $360,000</A></DIV><DIV CLASS="lnkr"><CITE>Gavin Dunaway / <A HREF="http://www.adotas.com/">Adotas</A>:</CITE> &nbsp; <A HREF="http://www.adotas.com/2010/11/got-funds-gnip-scores-2-million-after-twitter-data-selling-deal/">Got Funds? Gnip Scores $2 Million After Twitter Data-Selling Deal</A></DIV><DIV CLASS="lnkr"><CITE>Kevin Kelleher / <A HREF="http://blogs.reuters.com/mediafile">MediaFile</A>:</CITE> &nbsp; <A HREF="http://blogs.reuters.com/mediafile/2010/11/18/why-is-facebook-worth-ten-twitters/">Why is Facebook worth ten Twitters?</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p20"></A>
+<DIV CLASS="item" ID="101119p20" ONMOUSEOVER="nnid('13dx1')">
+<A HREF="http://www.guardian.co.uk/technology/2010/nov/19/google-street-view-data"><IMG CLASS="ill" SRC="/101119/i20.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p20#a101119p20" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s16');
+--></script>
+<CITE>Josh Halliday / <A HREF="http://www.guardian.co.uk/">Guardian</A>:</CITE>
+<span id="s16" pml="101119p20" spml="AJVJ" bitly="c5N5O8" url="http://www.guardian.co.uk/technology/2010/nov/19/google-street-view-data" head="Google to delete Street View data gathered in the UK (@joshhalliday / Guardian)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.guardian.co.uk/technology/2010/nov/19/google-street-view-data">Google to delete Street View data gathered in the UK</A></STRONG>&nbsp; &mdash;&nbsp; Technology giant signs commitment to improve its data handling after illegally capturing personal details from Wi-Fi networks&nbsp; &mdash;&nbsp; Google is to delete the sensitive information - including full emails and passwords &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.guardian.co.uk/technology/2010/nov/19/google-street-view-data');
+--></SCRIPT>
+<DIV ID="13d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('13dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="13dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('13',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.theregister.co.uk/2010/11/19/google_wi_fi/">The Register</A>, <A HREF="http://www.telegraph.co.uk/technology/google/8146575/Google-finally-to-delete-user-data.html">Telegraph</A> and <A HREF="http://thenextweb.com/google/2010/11/19/google-agrees-to-delete-street-view-user-data/">The Next Web</A></SPAN>
+</DIV></DIV>
+<DIV ID="13p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="13px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('13',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Lester Haines / <A HREF="http://www.theregister.co.uk/">The Register</A>:</CITE> &nbsp; <A HREF="http://www.theregister.co.uk/2010/11/19/google_wi_fi/">Google to scrub slurped UK Wi-Fi data</A></DIV><DIV CLASS="lnkr"><CITE>Matt Warman / <A HREF="http://www.telegraph.co.uk/">Telegraph</A>:</CITE> &nbsp; <A HREF="http://www.telegraph.co.uk/technology/google/8146575/Google-finally-to-delete-user-data.html">Google finally to delete user data</A></DIV><DIV CLASS="lnkr"><CITE>Matt Brian / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/google/2010/11/19/google-agrees-to-delete-street-view-user-data/">Google Agrees To Delete Street View User Data</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101118p48"></A>
+<DIV CLASS="item" ID="101118p48" ONMOUSEOVER="nnid('14dx1')">
+<A HREF="http://www.myspace.com/pressroom/2010/11/myspace-introduces-mashup-with-facebook/"><IMG CLASS="ill" SRC="/101118/i48.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p48#a101118p48" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s17');
+--></script>
+<CITE>Laurie Spindler / <A HREF="http://www.myspace.com/">MySpace</A>:</CITE>
+<span id="s17" pml="101118p48" spml="AJFk" bitly="cXjld9" url="http://www.myspace.com/pressroom/2010/11/myspace-introduces-mashup-with-facebook/" head="MYSPACE INTRODUCES MASHUP WITH FACEBOOK (@lauriespin / MySpace)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.myspace.com/pressroom/2010/11/myspace-introduces-mashup-with-facebook/">MYSPACE INTRODUCES MASHUP WITH FACEBOOK</A></STRONG>&nbsp; &mdash;&nbsp; Myspace Users Can Easily Create Highly Personalized, Entertainment-Focused Streams Based on their Facebook Profile&nbsp; &mdash;&nbsp; Today, Myspace announced Mashup with Facebook, a new feature that allows Myspace users to easily create a personalized stream of entertainment content.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.myspace.com/pressroom/2010/11/myspace-introduces-mashup-with-facebook/');
+--></SCRIPT>
+<DIV ID="14d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('14dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="14dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('14',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://musically.com/blog/2010/11/19/myspace-gets-mashed-up-with-facebook/">Music Ally</A>, <A HREF="http://mashable.com/2010/11/18/you-can-now-login-to-myspace-with-facebook/">Mashable!</A>, <A HREF="http://www.zdnet.com/blog/gadgetreviews/is-mashup-with-facebook-a-sign-of-the-end-for-myspace/20204">The Toybox Blog</A>, <A HREF="http://news.softpedia.com/news/MySpace-Announces-Facebook-Integration-167541.shtml">Softpedia News</A>, <A HREF="http://www.slashgear.com/myspace-mashup-opens-door-to-facebook-invasion-19115028/">SlashGear</A>, <A HREF="http://pulse2.com/2010/11/19/myspace-now-lets-you-pull-in-facebook-interests/">Pulse2</A>, <A HREF="http://www.insidefacebook.com/2010/11/18/myspace-mashup-ports-likes/">Inside Facebook</A>, <A HREF="http://www.gizmodo.com.au/2010/11/today-is-the-day-myspace-stopped-trying-to-matter/">Gizmodo Australia</A>, <A HREF="http://www.dailyfinance.com/story/media/myspace-launches-mashup-feature-with-facebook/19724599/">DailyFinance</A>, <A HREF="http://www.pcworld.com/article/211127/">PC World</A>, <A HREF="http://gigaom.com/2010/11/18/myspace-facebook/">GigaOM</A>, <A HREF="http://www.itproportal.com/2010/11/19/myspace-launches-mashup-facebook/">ITProPortal</A>, <A HREF="http://vator.tv/news/2010-11-18-myspace-mashes-up-with-facebook-connect">VatorNews</A>, <A HREF="http://gothamist.com/2010/11/18/myspace_submits_to_facebook_with_ma.php">Gothamist</A>, <A HREF="http://blogs.forbes.com/mikeisaac/2010/11/18/facebook-and-myspace-finally-friend-one-another/">Social Medium</A>, <A HREF="http://digitizor.com/2010/11/19/you-can-now-login-to-myspace-using-facebook/">Digitizor</A>, <A HREF="http://news.idg.no/cw/art.cfm?id=60EB7373-1A64-6A71-CE6AC2ECA2DCD6A2">Computerworld</A>, <A HREF="http://networkeffect.allthingsd.com/20101118/myspace-a-place-for-facebook-friends/">NetworkEffect</A>, <A HREF="http://news.yahoo.com/s/afp/20101118/ts_alt_afp/usitcompanyinternetmyspacefacebook">Agence France Presse</A>, <A HREF="http://techland.com/2010/11/18/myspace-integrates-facebook-universe-doesnt-collapse/">Techland</A>, <A HREF="http://blogs.forrester.com/augie_ray/10-11-18-facebook_and_myspace_collaborate_what_it_means_and_doesnt">Interactive Marketing</A>, <A HREF="http://www.blackweb20.com/2010/11/18/facebook-and-myspace-ultimate-mashup/">Black Web 2.0</A>, <A HREF="http://www.fastcompany.com/1703812/why-mashups-with-facebook-isnt-a-win-for-facebook-nor-a-loss-for-myspace">Fast Company</A>, <A HREF="http://www.nbcbayarea.com/news/tech/Facebook-MySpace-Schedule-a-Date-to-Kiss-and-Make-Up-108973419.html">NBC Bay Area</A>, <A HREF="http://www.techspot.com/news/41201-game-over-you-can-now-login-to-myspace-with-facebook.html">TechSpot</A>, <A HREF="http://techie-buzz.com/social-networking/myspace-facebook-mashup.html">Techie Buzz</A>, <A HREF="http://tech.fortune.cnn.com/2010/11/18/facebook-like-buttons-myspace/">Fortune</A>, <A HREF="http://www.sfgate.com/cgi-bin/blogs/techchron/detail?entry_id=77351">SFGate</A>, <A HREF="http://www.guardian.co.uk/technology/2010/nov/18/myspace-announces-mashup-facebook-collaboration">Guardian</A>, <A HREF="http://www.businessinsider.com/live-myspace-facebook-announcement-2010-11">SAI</A>, <A HREF="http://www.downloadsquad.com/2010/11/18/facebook-does-a-mashup-with-myspace-syncs-likes-across-servic/">Download Squad</A>, <A HREF="http://www.switched.com/2010/11/18/myspace-mashup-with-facebook-gives-up/">Switched</A>, <A HREF="http://www.allfacebook.com/live-myspace-announces-mashup-with-facebook-2010-11">All Facebook</A>, <A HREF="http://news.cnet.com/8301-30684_3-20023303-265.html">Relevant Results</A>, <A HREF="http://www.businessinsider.com/facebook-and-myspace-schedule-joint-announcement-for-thursday-2010-11">The Business Insider</A> and <A HREF="http://techcrunch.com/2010/11/18/hell-freezes-over-as-myspace-fully-surrenders-to-facebook/">TechCrunch</A></SPAN>
+</DIV></DIV>
+<DIV ID="14p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="14px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('14',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE><A HREF="http://musically.com/blog">Music Ally</A>:</CITE> &nbsp; <A HREF="http://musically.com/blog/2010/11/19/myspace-gets-mashed-up-with-facebook/">MySpace gets mashed up with Facebook</A></DIV><DIV CLASS="lnkr"><CITE>Adam Ostrow / <A HREF="http://mashable.com/">Mashable!</A>:</CITE> &nbsp; <A HREF="http://mashable.com/2010/11/18/you-can-now-login-to-myspace-with-facebook/">You Can Now Log in to MySpace with Facebook</A></DIV><DIV CLASS="lnkr"><CITE>Rachel King / <A HREF="http://www.zdnet.com/blog/gadgetreviews">The Toybox Blog</A>:</CITE> &nbsp; <A HREF="http://www.zdnet.com/blog/gadgetreviews/is-mashup-with-facebook-a-sign-of-the-end-for-myspace/20204">Is Mashup with Facebook a sign of the end for Myspace?</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.softpedia.com/">Softpedia News</A>:</CITE> &nbsp; <A HREF="http://news.softpedia.com/news/MySpace-Announces-Facebook-Integration-167541.shtml">MySpace Announces Facebook Integration</A></DIV><DIV CLASS="lnkr"><CITE>Chris Davies / <A HREF="http://www.slashgear.com/">SlashGear</A>:</CITE> &nbsp; <A HREF="http://www.slashgear.com/myspace-mashup-opens-door-to-facebook-invasion-19115028/">Myspace &ldquo;mashup&rdquo; opens door to Facebook invasion</A></DIV><DIV CLASS="lnkr"><CITE>Amit Chowdhry / <A HREF="http://pulse2.com/">Pulse2</A>:</CITE> &nbsp; <A HREF="http://pulse2.com/2010/11/19/myspace-now-lets-you-pull-in-facebook-interests/">MySpace Now Lets You Pull In Facebook Interests</A></DIV><DIV CLASS="lnkr"><CITE>Josh Constine / <A HREF="http://www.insidefacebook.com/">Inside Facebook</A>:</CITE> &nbsp; <A HREF="http://www.insidefacebook.com/2010/11/18/myspace-mashup-ports-likes/">MySpace's &ldquo;Mashup with Facebook&rdquo; Ports Likes to Populate Its Stream</A></DIV><DIV CLASS="lnkr"><CITE>Sam Biddle / <A HREF="http://www.gizmodo.com.au/">Gizmodo Australia</A>:</CITE> &nbsp; <A HREF="http://www.gizmodo.com.au/2010/11/today-is-the-day-myspace-stopped-trying-to-matter/">Today Is The Day MySpace Stopped Trying To Matter</A></DIV><DIV CLASS="lnkr"><CITE>Danny King / <A HREF="http://www.dailyfinance.com/category/technology/">DailyFinance</A>:</CITE> &nbsp; <A HREF="http://www.dailyfinance.com/story/media/myspace-launches-mashup-feature-with-facebook/19724599/">MySpace Launches &lsquo;Mashup&rsquo; Feature With Facebook</A></DIV><DIV CLASS="lnkr"><CITE>JR Raphael / <A HREF="http://www.pcworld.com/">PC World</A>:</CITE> &nbsp; <A HREF="http://www.pcworld.com/article/211127/">Myspace's Facebook &lsquo;Mashup&rsquo; &mdash; Why Bother?</A></DIV><DIV CLASS="lnkr"><CITE>Mathew Ingram / <A HREF="http://gigaom.com/">GigaOM</A>:</CITE> &nbsp; <A HREF="http://gigaom.com/2010/11/18/myspace-facebook/">Myspace Cries Uncle, Hands Lunch Money to Facebook</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.itproportal.com/">ITProPortal</A>:</CITE> &nbsp; <A HREF="http://www.itproportal.com/2010/11/19/myspace-launches-mashup-facebook/">Myspace Launches Mashup With Facebook</A></DIV><DIV CLASS="lnkr"><CITE>Ronny Kerr / <A HREF="http://vator.tv/news/">VatorNews</A>:</CITE> &nbsp; <A HREF="http://vator.tv/news/2010-11-18-myspace-mashes-up-with-facebook-connect">MySpace mashes up with Facebook Connect</A></DIV><DIV CLASS="lnkr"><CITE>John Del Signore / <A HREF="http://gothamist.com/">Gothamist</A>:</CITE> &nbsp; <A HREF="http://gothamist.com/2010/11/18/myspace_submits_to_facebook_with_ma.php">MySpace Submits to Facebook with &ldquo;Mashup&rdquo; Collaboration</A></DIV><DIV CLASS="lnkr"><CITE>Mike Isaac / <A HREF="http://blogs.forbes.com/mikeisaac">Social Medium</A>:</CITE> &nbsp; <A HREF="http://blogs.forbes.com/mikeisaac/2010/11/18/facebook-and-myspace-finally-friend-one-another/">Facebook and Myspace Finally &lsquo;Friend&rsquo; One Another</A></DIV><DIV CLASS="lnkr"><CITE>Ricky / <A HREF="http://digitizor.com/">Digitizor</A>:</CITE> &nbsp; <A HREF="http://digitizor.com/2010/11/19/you-can-now-login-to-myspace-using-facebook/">MySpace Announces &ldquo;Mashup With Facebook&rdquo; - Allows Login Through Facebook</A></DIV><DIV CLASS="lnkr"><CITE>Sharon Gaudin / <A HREF="http://computerworld.com/">Computerworld</A>:</CITE> &nbsp; <A HREF="http://news.idg.no/cw/art.cfm?id=60EB7373-1A64-6A71-CE6AC2ECA2DCD6A2">Facebook dethrones MySpace as social network</A></DIV><DIV CLASS="lnkr"><CITE>Liz Gannes / <A HREF="http://networkeffect.allthingsd.com/">NetworkEffect</A>:</CITE> &nbsp; <A HREF="http://networkeffect.allthingsd.com/20101118/myspace-a-place-for-facebook-friends/">Myspace: A Place for Facebook Friends</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.yahoo.com/i/1504">Agence France Presse</A>:</CITE> &nbsp; <A HREF="http://news.yahoo.com/s/afp/20101118/ts_alt_afp/usitcompanyinternetmyspacefacebook">MySpace deepens ties with rival Facebook</A></DIV><DIV CLASS="lnkr"><CITE>Doug Aamoth / <A HREF="http://techland.com/">Techland</A>:</CITE> &nbsp; <A HREF="http://techland.com/2010/11/18/myspace-integrates-facebook-universe-doesnt-collapse/">MySpace Integrates Facebook, Universe Doesn't Collapse</A></DIV><DIV CLASS="lnkr"><CITE>Augie Ray / <A HREF="http://blogs.forrester.com/taxonomy/term/18/all">Interactive Marketing</A>:</CITE> &nbsp; <A HREF="http://blogs.forrester.com/augie_ray/10-11-18-facebook_and_myspace_collaborate_what_it_means_and_doesnt">Facebook and Myspace Collaborate - What it Means (and Doesn't)</A></DIV><DIV CLASS="lnkr"><CITE>Rahsheen / <A HREF="http://www.blackweb20.com/">Black Web 2.0</A>:</CITE> &nbsp; <A HREF="http://www.blackweb20.com/2010/11/18/facebook-and-myspace-ultimate-mashup/">Facebook and MySpace: Ultimate Mashup</A></DIV><DIV CLASS="lnkr"><CITE>E.B. Boyd / <A HREF="http://www.fastcompany.com/">Fast Company</A>:</CITE> &nbsp; <A HREF="http://www.fastcompany.com/1703812/why-mashups-with-facebook-isnt-a-win-for-facebook-nor-a-loss-for-myspace">Why &ldquo;Mashups With Facebook&rdquo; Isn't a Loss for MySpace</A></DIV><DIV CLASS="lnkr"><CITE>Sajid Farooq / <A HREF="http://www.nbcbayarea.com/news/tech">NBC Bay Area</A>:</CITE> &nbsp; <A HREF="http://www.nbcbayarea.com/news/tech/Facebook-MySpace-Schedule-a-Date-to-Kiss-and-Make-Up-108973419.html">Facebook, MySpace Kiss and Make-Up</A></DIV><DIV CLASS="lnkr"><CITE>Emil Protalinski / <A HREF="http://www.techspot.com/">TechSpot</A>:</CITE> &nbsp; <A HREF="http://www.techspot.com/news/41201-game-over-you-can-now-login-to-myspace-with-facebook.html">Game over: you can now login to MySpace with Facebook</A></DIV><DIV CLASS="lnkr"><CITE>Keith Dsouza / <A HREF="http://techie-buzz.com/">Techie Buzz</A>:</CITE> &nbsp; <A HREF="http://techie-buzz.com/social-networking/myspace-facebook-mashup.html">Myspace Announces Mashup With Facebook</A></DIV><DIV CLASS="lnkr"><CITE>JP Mangalindan / <A HREF="http://www.fortune.com/">Fortune</A>:</CITE> &nbsp; <A HREF="http://tech.fortune.cnn.com/2010/11/18/facebook-like-buttons-myspace/">Facebook Like-buttons MySpace</A></DIV><DIV CLASS="lnkr"><CITE>Benny Evangelista / <A HREF="http://www.sfgate.com/cgi-bin/blogs/techchron/index">SFGate</A>:</CITE> &nbsp; <A HREF="http://www.sfgate.com/cgi-bin/blogs/techchron/detail?entry_id=77351">MySpace announces &ldquo;Mashup with Facebook&rdquo;</A></DIV><DIV CLASS="lnkr"><CITE>Josh Halliday / <A HREF="http://www.guardian.co.uk/">Guardian</A>:</CITE> &nbsp; <A HREF="http://www.guardian.co.uk/technology/2010/nov/18/myspace-announces-mashup-facebook-collaboration">MySpace in &lsquo;mashup&rsquo; with Facebook</A></DIV><DIV CLASS="lnkr"><CITE>Jay Yarow / <A HREF="http://www.businessinsider.com/sai">SAI: Silicon Alley Insider</A>:</CITE> &nbsp; <A HREF="http://www.businessinsider.com/live-myspace-facebook-announcement-2010-11">Myspace Does A &ldquo;Mashup&rdquo; With Facebook</A></DIV><DIV CLASS="lnkr"><CITE>Jay Hathaway / <A HREF="http://www.downloadsquad.com/">Download Squad</A>:</CITE> &nbsp; <A HREF="http://www.downloadsquad.com/2010/11/18/facebook-does-a-mashup-with-myspace-syncs-likes-across-servic/">Facebook does a Mashup with MySpace, syncs &lsquo;likes&rsquo; across services</A></DIV><DIV CLASS="lnkr"><CITE>Terrence O'Brien / <A HREF="http://www.switched.com/">Switched</A>:</CITE> &nbsp; <A HREF="http://www.switched.com/2010/11/18/myspace-mashup-with-facebook-gives-up/">With &lsquo;Mashup,&rsquo; MySpace Gives Up, Becomes Conduit for Facebook</A></DIV><DIV CLASS="lnkr"><CITE>Nick O'Neill / <A HREF="http://www.allfacebook.com/">All Facebook</A>:</CITE> &nbsp; <A HREF="http://www.allfacebook.com/live-myspace-announces-mashup-with-facebook-2010-11">LIVE: MySpace Announces Mashup With Facebook</A></DIV><DIV CLASS="lnkr"><CITE>Tom Krazit / <A HREF="http://news.cnet.com/relevant-results/">Relevant Results</A>:</CITE> &nbsp; <A HREF="http://news.cnet.com/8301-30684_3-20023303-265.html">MySpace &lsquo;Mashup&rsquo; adds Facebook Connect</A></DIV><DIV CLASS="lnkr"><CITE>Dan Frommer / <A HREF="http://www.businessinsider.com/">The Business Insider</A>:</CITE> &nbsp; <A HREF="http://www.businessinsider.com/facebook-and-myspace-schedule-joint-announcement-for-thursday-2010-11">Facebook And MySpace Schedule Joint Announcement For Thursday</A></DIV><DIV CLASS="lnkr"><CITE>Michael Arrington / <A HREF="http://techcrunch.com/">TechCrunch</A>:</CITE> &nbsp; <A HREF="http://techcrunch.com/2010/11/18/hell-freezes-over-as-myspace-fully-surrenders-to-facebook/">Hell Freezes Over As MySpace Fully Surrenders To Facebook</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p10"></A>
+<DIV CLASS="item" ID="101119p10" ONMOUSEOVER="nnid('15dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p10#a101119p10" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s18');
+--></script>
+<CITE>Tana Ganeva / <A HREF="http://www.alternet.org/">AlterNet</A>:</CITE>
+<span id="s18" pml="101119p10" spml="AJV=" bitly="aXrwEn" url="http://www.alternet.org/newsandviews/article/337982/debt_collectors_stalking,_publicly_shaming_people_through_facebook/" head="Debt Collectors Stalking, Publicly Shaming People Through Facebook (Tana Ganeva / AlterNet)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.alternet.org/newsandviews/article/337982/debt_collectors_stalking,_publicly_shaming_people_through_facebook/">Debt Collectors Stalking, Publicly Shaming People Through Facebook</A></STRONG>&nbsp; &mdash;&nbsp; Now that we have debtor's prison again, it's only natural that Americans who owe money be publicly shamed for the sin of being broke during a devastating recession.&nbsp; &mdash;&nbsp; A Tampa woman who fell behind on her car payments &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.alternet.org/newsandviews/article/337982/debt_collectors_stalking,_publicly_shaming_people_through_facebook/');
+--></SCRIPT>
+<DIV ID="15d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('15dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="15dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('15',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://consumerist.com/2010/11/debt-collectors-exploit-facebook-to-embarrass-you-to-friends-and-family.html">The Consumerist</A> and <A HREF="http://infocult.typepad.com/infocult/2010/11/facebook-the-debt-stalkers-tool.html">Infocult</A></SPAN>
+</DIV></DIV>
+<DIV ID="15p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="15px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('15',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Ben Popken / <A HREF="http://consumerist.com/">The Consumerist</A>:</CITE> &nbsp; <A HREF="http://consumerist.com/2010/11/debt-collectors-exploit-facebook-to-embarrass-you-to-friends-and-family.html">Debt Collectors Exploit Facebook To Embarrass You To Friends And Family</A></DIV><DIV CLASS="lnkr"><CITE>Bryan Alexander / <A HREF="http://infocult.typepad.com/infocult/">Infocult</A>:</CITE> &nbsp; <A HREF="http://infocult.typepad.com/infocult/2010/11/facebook-the-debt-stalkers-tool.html">Facebook, the debt stalker's tool</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p18"></A>
+<DIV CLASS="item" ID="101119p18" ONMOUSEOVER="nnid('16dx1')">
+<A HREF="http://www.readwriteweb.com/cloud/2010/11/salesforcecoms-chatter-to-go-f.php"><IMG CLASS="ill" SRC="/101119/i18.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p18#a101119p18" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s19');
+--></script>
+<CITE>Klint Finley / <A HREF="http://www.readwriteweb.com/">ReadWriteWeb</A>:</CITE>
+<span id="s19" pml="101119p18" spml="AJVH" bitly="aQ2hTD" url="http://www.readwriteweb.com/cloud/2010/11/salesforcecoms-chatter-to-go-f.php" head="Salesforce.com's Chatter to Go Freemium (@klintron / ReadWriteWeb)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.readwriteweb.com/cloud/2010/11/salesforcecoms-chatter-to-go-f.php">Salesforce.com's Chatter to Go Freemium</A></STRONG>&nbsp; &mdash;&nbsp; Salesforce.com CEO Marc Benioff reportedly told analysts today that the company will announce a free version of its enterprise activity stream product Chatter at the annual Dreamforce event in San Francisco next month.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.readwriteweb.com/cloud/2010/11/salesforcecoms-chatter-to-go-f.php');
+--></SCRIPT>
+<DIV ID="16d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('16dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="16dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('16',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.crn.com/news/applications-os/228300201/salesforce-to-debut-free-version-of-chatter-at-dreamforce.htm-XWwAnsA**.ecappj01">CRN</A>, <A HREF="http://thenextweb.com/apps/2010/11/19/more-social-freemium-chatter-coming-from-salesforce-com/">The Next Web</A>, <A HREF="http://www.zdnet.com/blog/btl/salesforcecom-free-stripped-down-chatter-on-deck/41941">Between the Lines Blog</A> and <A HREF="http://www.zdnet.com/blog/sommer/interview-narinder-singh-of-appirio/957">Software &amp; Services &hellip;</A></SPAN>
+</DIV></DIV>
+<DIV ID="16p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="16px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('16',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Rick Whiting / <A HREF="http://www.crn.com/">CRN</A>:</CITE> &nbsp; <A HREF="http://www.crn.com/news/applications-os/228300201/salesforce-to-debut-free-version-of-chatter-at-dreamforce.htm-XWwAnsA**.ecappj01">Salesforce To Debut Free Version Of Chatter At Dreamforce</A></DIV><DIV CLASS="lnkr"><CITE>Tris Hussey / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/apps/2010/11/19/more-social-freemium-chatter-coming-from-salesforce-com/">More Social, Freemium Chatter Coming from Salesforce.com</A></DIV><DIV CLASS="lnkr"><CITE>Larry Dignan / <A HREF="http://www.zdnet.com/blog/btl">Between the Lines Blog</A>:</CITE> &nbsp; <A HREF="http://www.zdnet.com/blog/btl/salesforcecom-free-stripped-down-chatter-on-deck/41941">Salesforce.com: Free stripped down Chatter on deck</A></DIV><DIV CLASS="lnkr"><CITE>Brian Sommer / <A HREF="http://www.zdnet.com/blog/sommer">Software &amp; Services Safari Blog</A>:</CITE> &nbsp; <A HREF="http://www.zdnet.com/blog/sommer/interview-narinder-singh-of-appirio/957">Interview: Narinder Singh of Appirio</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p19"></A>
+<DIV CLASS="item" ID="101119p19" ONMOUSEOVER="nnid('17dx1')">
+<A HREF="http://online.wsj.com/article/SB10001424052748703374304575622884122938068.html"><IMG CLASS="ill" SRC="/101119/i19.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p19#a101119p19" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s20');
+--></script>
+<CITE>Shayndi Raice / <A HREF="http://online.wsj.com/public/us">Wall Street Journal</A>:</CITE>
+<span id="s20" pml="101119p19" spml="AJVI" bitly="dqBSMX" url="http://online.wsj.com/article/SB10001424052748703374304575622884122938068.html" head="Small Deal Brings Scrutiny to Huawei (@shayndi / Wall Street Journal)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://online.wsj.com/article/SB10001424052748703374304575622884122938068.html">Small Deal Brings Scrutiny to Huawei</A></STRONG>&nbsp; &mdash;&nbsp; Huawei Technologies Ltd., whose efforts to buy big U.S. companies have been stymied by security concerns, has landed in hot water in Washington for acquiring a small technology firm without first running the deal by the government.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://online.wsj.com/article/SB10001424052748703374304575622884122938068.html');
+--></SCRIPT>
+<DIV ID="17d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('17dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="17dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('17',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.techeye.net/business/huawei-angers-us-government-with-undeclared-acquisition">TechEye</A> and <A HREF="http://news.idg.no/cw/art.cfm?id=6370CBD6-1A64-67EA-E4CCFB073AC336A3">Computerworld</A></SPAN>
+</DIV></DIV>
+<DIV ID="17p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="17px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('17',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Dean Wilson / <A HREF="http://www.techeye.net/">TechEye</A>:</CITE> &nbsp; <A HREF="http://www.techeye.net/business/huawei-angers-us-government-with-undeclared-acquisition">Huawei angers US government with undeclared acquisition</A></DIV><DIV CLASS="lnkr"><CITE>Michael Kan / <A HREF="http://computerworld.com/">Computerworld</A>:</CITE> &nbsp; <A HREF="http://news.idg.no/cw/art.cfm?id=6370CBD6-1A64-67EA-E4CCFB073AC336A3">Report: Pentagon officials want review of Huawei deal</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p14"></A>
+<DIV CLASS="item" ID="101119p14" ONMOUSEOVER="nnid('18dx1')">
+<A HREF="http://edition.cnn.com/2010/TECH/social.media/11/19/twitter.china/"><IMG CLASS="ill" SRC="/101119/i14.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p14#a101119p14" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s21');
+--></script>
+<CITE>Mark Milian / <A HREF="http://www.cnn.com/">CNN</A>:</CITE>
+<span id="s21" pml="101119p14" spml="AJVD" bitly="9VztBw" url="http://edition.cnn.com/2010/TECH/social.media/11/19/twitter.china/" head="Twitter CEO chides China (@markmilian / CNN)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://edition.cnn.com/2010/TECH/social.media/11/19/twitter.china/">Twitter CEO chides China</A></STRONG>&nbsp; &mdash;&nbsp; (CNN) &mdash; &ldquo;Dear Chinese Government,&rdquo; began a message sent late Thursday from Twitter CEO Dick Costolo.&nbsp; &mdash;&nbsp; &ldquo;Year-long detentions for sending a sarcastic tweet are neither the way forward nor the future of your great people,&rdquo; he wrote on his Twitter profile.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://edition.cnn.com/2010/TECH/social.media/11/19/twitter.china/');
+--></SCRIPT>
+<DIV ID="18d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('18dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="18dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('18',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.bbc.co.uk/news/world-asia-pacific-11784603">BBC</A></SPAN>
+</DIV></DIV>
+<DIV ID="18p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="18px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('18',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Damian Grammaticas / <A HREF="http://news.bbc.co.uk/">BBC</A>:</CITE> &nbsp; <A HREF="http://www.bbc.co.uk/news/world-asia-pacific-11784603">Chinese woman jailed over Twitter post</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p23"></A>
+<DIV CLASS="item" ID="101119p23" ONMOUSEOVER="nnid('19dx1')">
+<A HREF="http://www.tuaw.com/2010/11/19/mac-os-x-10-6-5-fixes-macbook-air-display-issues/"><IMG CLASS="ill" SRC="/101119/i23.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p23#a101119p23" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s22');
+--></script>
+<CITE>Michael Grothaus / <A HREF="http://www.tuaw.com/">TUAW</A>:</CITE>
+<span id="s22" pml="101119p23" spml="AJVM" bitly="chRsg7" url="http://www.tuaw.com/2010/11/19/mac-os-x-10-6-5-fixes-macbook-air-display-issues/" head="Mac OS X 10.6.5 fixes MacBook Air display issues (@michaelgrothaus / TUAW)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.tuaw.com/2010/11/19/mac-os-x-10-6-5-fixes-macbook-air-display-issues/">Mac OS X 10.6.5 fixes MacBook Air display issues</A></STRONG>&nbsp; &mdash;&nbsp; As noted by Mac Rumors, the Mac OS X 10.6.5 software update released last week fixes the display issues some owners were having with their new MacBook Airs.&nbsp; In a new support document released today titled MacBook Air (Late 2010) &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.tuaw.com/2010/11/19/mac-os-x-10-6-5-fixes-macbook-air-display-issues/');
+--></SCRIPT>
+<DIV ID="19d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('19dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="19dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('19',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://support.apple.com/kb/TS3589">Apple</A>, <A HREF="http://www.macrumors.com/2010/11/18/mac-os-x-10-6-5-addresses-display-issues-on-new-macbook-air/">MacRumors</A>, <A HREF="http://www.downloadsquad.com/2010/11/19/airprint-on-mac-os-x-with-printopia-and-fingerprint/">Download Squad</A>, <A HREF="http://www.pcworld.com/article/210840/">PC World</A>, <A HREF="http://www.slashgear.com/macbook-air-display-woes-addressed-with-os-x-10-6-5-19115075/">SlashGear</A>, <A HREF="http://www.i4u.com/42744/macbook-air-display-issues-are-already-fixed-os-x-1065">I4U News</A>, <A HREF="http://news.softpedia.com/news/Apple-Includes-Surprise-MacBook-Air-Fix-with-Mac-OS-X-10-6-5-167540.shtml">Softpedia News</A> and <A HREF="http://www.macstories.net/mac/mac-os-x-10-6-5-update-fixes-macbook-air-graphic-issues/">MacStories</A></SPAN>
+</DIV></DIV>
+<DIV ID="19p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="19px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('19',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE><A HREF="http://support.apple.com/">Apple</A>:</CITE> &nbsp; <A HREF="http://support.apple.com/kb/TS3589">MacBook Air (Late 2010): Video anomalies after waking from sleep</A></DIV><DIV CLASS="lnkr"><CITE>Eric Slivka / <A HREF="http://www.macrumors.com/">MacRumors</A>:</CITE> &nbsp; <A HREF="http://www.macrumors.com/2010/11/18/mac-os-x-10-6-5-addresses-display-issues-on-new-macbook-air/">Mac OS X 10.6.5 Addresses Display Issues on New MacBook Air</A></DIV><DIV CLASS="lnkr"><CITE>Samuel Gibbs / <A HREF="http://www.downloadsquad.com/">Download Squad</A>:</CITE> &nbsp; <A HREF="http://www.downloadsquad.com/2010/11/19/airprint-on-mac-os-x-with-printopia-and-fingerprint/">AirPrint on Mac OS X with Printopia and FingerPrint</A></DIV><DIV CLASS="lnkr"><CITE>Alex Wawro / <A HREF="http://www.pcworld.com/">PC World</A>:</CITE> &nbsp; <A HREF="http://www.pcworld.com/article/210840/">MacBook Air Outperforms Most Windows Netbooks and Ultraportables</A></DIV><DIV CLASS="lnkr"><CITE>Shane McGlaun / <A HREF="http://www.slashgear.com/">SlashGear</A>:</CITE> &nbsp; <A HREF="http://www.slashgear.com/macbook-air-display-woes-addressed-with-os-x-10-6-5-19115075/">MacBook Air display woes addressed with OS X 10.6.5</A></DIV><DIV CLASS="lnkr"><CITE>Luigi Lugmayr / <A HREF="http://www.i4u.com/">I4U News</A>:</CITE> &nbsp; <A HREF="http://www.i4u.com/42744/macbook-air-display-issues-are-already-fixed-os-x-1065">MacBook Air Display Issues are already fixed in OS X 10.6.5</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.softpedia.com/">Softpedia News</A>:</CITE> &nbsp; <A HREF="http://news.softpedia.com/news/Apple-Includes-Surprise-MacBook-Air-Fix-with-Mac-OS-X-10-6-5-167540.shtml">Apple Includes Surprise MacBook Air Fix with Mac OS X 10.6.5</A></DIV><DIV CLASS="lnkr"><CITE>Federico Viticci / <A HREF="http://www.macstories.net/">MacStories</A>:</CITE> &nbsp; <A HREF="http://www.macstories.net/mac/mac-os-x-10-6-5-update-fixes-macbook-air-graphic-issues/">Mac OS X 10.6.5 Update Fixes MacBook Air Graphic Issues</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p24"></A>
+<DIV CLASS="item" ID="101119p24" ONMOUSEOVER="nnid('20dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p24#a101119p24" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s23');
+--></script>
+<CITE><A HREF="http://www.electronista.com/">Electronista</A>:</CITE><SPAN CLASS="recent">30&nbsp;minutes&nbsp;ago</SPAN>
+<span id="s23" pml="101119p24" spml="AJVN" bitly="aU1mJb" url="http://www.electronista.com/articles/10/11/18/euro.carriers.warn.apple.over.embedded.sims/" head="Carriers threaten Apple over talk of embedded iPhone SIMs (Electronista)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.electronista.com/articles/10/11/18/euro.carriers.warn.apple.over.embedded.sims/">Carriers threaten Apple over talk of embedded iPhone SIMs</A></STRONG>&nbsp; &mdash;&nbsp; European carriers are discussing the possibility of retaliating against Apple if it goes ahead with a rumored plan to use embedded SIMs in iPhones, leaks from the industry alleged Thursday night.&nbsp; The parent companies of O2 &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.electronista.com/articles/10/11/18/euro.carriers.warn.apple.over.embedded.sims/');
+--></SCRIPT>
+<DIV ID="20d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('20dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="20dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('20',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.macrumors.com/2010/11/19/carriers-objecting-to-apples-plans-for-built-in-iphone-sim-card-even-as-gsma-moves-forward/">MacRumors</A>, <A HREF="http://www.ft.com/cms/s/0/db917464-f344-11df-a4fa-00144feab49a.html">Financial Times</A> and <A HREF="http://www.mobileburn.com/news.jsp?Id=11763">MobileBurn.com</A></SPAN>
+</DIV></DIV>
+<DIV ID="20p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="20px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('20',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Eric Slivka / <A HREF="http://www.macrumors.com/">MacRumors</A>:</CITE> &nbsp; <A HREF="http://www.macrumors.com/2010/11/19/carriers-objecting-to-apples-plans-for-built-in-iphone-sim-card-even-as-gsma-moves-forward/">Carriers Objecting to Apple's Plans for Built-In iPhone SIM Card &hellip; </A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.ft.com/">Financial Times</A>:</CITE> &nbsp; <A HREF="http://www.ft.com/cms/s/0/db917464-f344-11df-a4fa-00144feab49a.html">Apple warned over built-in Sim cards</A></DIV><DIV CLASS="lnkr"><CITE>Todd Haselton / <A HREF="http://www.mobileburn.com/">MobileBurn.com</A>:</CITE> &nbsp; <A HREF="http://www.mobileburn.com/news.jsp?Id=11763">Apple iPhone embedded SIM could spark war with European carriers</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p15"></A>
+<DIV CLASS="item" ID="101119p15" ONMOUSEOVER="nnid('21dx1')">
+<A HREF="http://conversations.nokia.com/2010/11/18/evp-niklas-savander-discusses-nokia-n8-quality/"><IMG CLASS="ill" SRC="/101119/i15.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p15#a101119p15" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s24');
+--></script>
+<CITE>Phil / <A HREF="http://conversations.nokia.com/">Nokia Conversations</A>:</CITE>
+<span id="s24" pml="101119p15" spml="AJVE" bitly="aI0BxX" url="http://conversations.nokia.com/2010/11/18/evp-niklas-savander-discusses-nokia-n8-quality/" head="EVP Niklas Savander discusses Nokia N8 quality (Phil / Nokia Conversations)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://conversations.nokia.com/2010/11/18/evp-niklas-savander-discusses-nokia-n8-quality/">EVP Niklas Savander discusses Nokia N8 quality</A></STRONG>&nbsp; &mdash;&nbsp; GLOBAL - We have been getting excellent feedback from consumers on the capabilities of the Nokia N8, but in the last couple of days, a very small number of users have reported that their Nokia N8 is not switching on as it should.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://conversations.nokia.com/2010/11/18/evp-niklas-savander-discusses-nokia-n8-quality/');
+--></SCRIPT>
+<DIV ID="21d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('21dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="21dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('21',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.eweek.com/c/a/Mobile-and-Wireless/Nokia-N8-Smartphones-Having-BootUp-Problems-154650/">eWeek</A>, <A HREF="http://www.theinquirer.net/inquirer/news/1899308/nokia-admits-n8-power-management-fault?WT.rss_f=News&WT.rss_a=Nokia+admits+to+N8+power+management+fault">Inquirer</A>, <A HREF="http://www.networkworld.com/news/2010/111910-manufacturing-problems-hit-nokia-n8.html">Network World</A>, <A HREF="http://www.phonearena.com/news/Nokia-small-number-of-Nokia-N8-phones-fail-turning-on-warranty-will-cover_id14787">PhoneArena</A>, <A HREF="http://www.techeye.net/mobile/nokia-n8-turns-off-but-not-on">TechEye</A>, <A HREF="http://www.slashgear.com/nokia-n8-power-problems-officially-acknowledged-video-19115031/">SlashGear</A>, <A HREF="http://venturebeat.com/2010/11/18/nokias-n8-smartphone-facing-power-issues/">VentureBeat</A>, <A HREF="http://www.engadget.com/2010/11/18/nokia-says-very-small-number-of-n8s-arent-turning-on-warrant/">Engadget</A>, <A HREF="http://pocketnow.com/tech-news/nokia-admits-some-n8-models-are-faulty-promises-replacement">pocketnow.com</A>, <A HREF="http://www.v3.co.uk/v3/news/2273321/smartphones-nokia-n8-symbian">V3.co.uk</A>, <A HREF="http://www.geek.com/articles/mobile/nokia-admits-some-n8-smartphones-are-dying-20101118/">Geek.com</A>, <A HREF="http://news.softpedia.com/news/Nokia-Admits-to-N8-Power-Management-Issues-167436.shtml">Softpedia News</A>, <A HREF="http://thenextweb.com/mobile/2010/11/18/nokia-confirms-n8-power-management-issue/">The Next Web</A>, <A HREF="http://www.electronista.com/articles/10/11/18/nokia.says.n8.plagued.by.power.issue.c7.likely/">Electronista</A>, <A HREF="http://www.bgr.com/2010/11/18/nokia-some-n8-units-have-a-power-management-issue/">BGR</A>, <A HREF="http://channel.hexus.net/content/item.php?item=27590">HEXUS.channel</A>, <A HREF="http://www.ubergizmo.com/15/archives/2010/11/failing_nokia_n8_suffering_from_faulty_parts.html">Ubergizmo</A> and <A HREF="http://www.mobileburn.com/news.jsp?Id=11760">MobileBurn.com</A></SPAN>
+</DIV></DIV>
+<DIV ID="21p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="21px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('21',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Michelle Maisto / <A HREF="http://www.eweek.com/">eWeek</A>:</CITE> &nbsp; <A HREF="http://www.eweek.com/c/a/Mobile-and-Wireless/Nokia-N8-Smartphones-Having-BootUp-Problems-154650/">Nokia N8 Smartphones Having Boot-Up Problems</A></DIV><DIV CLASS="lnkr"><CITE>Lawrence Latif / <A HREF="http://www.theinquirer.net/">Inquirer</A>:</CITE> &nbsp; <A HREF="http://www.theinquirer.net/inquirer/news/1899308/nokia-admits-n8-power-management-fault?WT.rss_f=News&WT.rss_a=Nokia+admits+to+N8+power+management+fault">Nokia admits to N8 power management fault</A></DIV><DIV CLASS="lnkr"><CITE>Mikael Rickn&auml;s / <A HREF="http://www.networkworld.com/">Network World</A>:</CITE> &nbsp; <A HREF="http://www.networkworld.com/news/2010/111910-manufacturing-problems-hit-nokia-n8.html">Manufacturing problems hit Nokia N8 smartphone</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.phonearena.com/">Phone Arena</A>:</CITE> &nbsp; <A HREF="http://www.phonearena.com/news/Nokia-small-number-of-Nokia-N8-phones-fail-turning-on-warranty-will-cover_id14787">Nokia: &ldquo;small number&rdquo; of Nokia N8 phones fail turning on, warranty will cover</A></DIV><DIV CLASS="lnkr"><CITE>Andrea Petrou / <A HREF="http://www.techeye.net/">TechEye</A>:</CITE> &nbsp; <A HREF="http://www.techeye.net/mobile/nokia-n8-turns-off-but-not-on">Nokia N8 turns off but not on</A></DIV><DIV CLASS="lnkr"><CITE>Chris Davies / <A HREF="http://www.slashgear.com/">SlashGear</A>:</CITE> &nbsp; <A HREF="http://www.slashgear.com/nokia-n8-power-problems-officially-acknowledged-video-19115031/">Nokia N8 power problems officially acknowledged [Video]</A></DIV><DIV CLASS="lnkr"><CITE>Devindra Hardawar / <A HREF="http://venturebeat.com/">VentureBeat</A>:</CITE> &nbsp; <A HREF="http://venturebeat.com/2010/11/18/nokias-n8-smartphone-facing-power-issues/">Nokia's N8 smartphone facing power issues</A></DIV><DIV CLASS="lnkr"><CITE>Chris Ziegler / <A HREF="http://www.engadget.com/">Engadget</A>:</CITE> &nbsp; <A HREF="http://www.engadget.com/2010/11/18/nokia-says-very-small-number-of-n8s-arent-turning-on-warrant/">Nokia says &lsquo;very small&rsquo; number of N8s aren't turning on, warranty will cover it</A></DIV><DIV CLASS="lnkr"><CITE>Anton D. Nagy / <A HREF="http://pocketnow.com/">pocketnow.com</A>:</CITE> &nbsp; <A HREF="http://pocketnow.com/tech-news/nokia-admits-some-n8-models-are-faulty-promises-replacement">Nokia Admits Some N8 Models Are Faulty; Promises Replacement</A></DIV><DIV CLASS="lnkr"><CITE>Khidr Suleman / <A HREF="http://www.v3.co.uk/">V3.co.uk</A>:</CITE> &nbsp; <A HREF="http://www.v3.co.uk/v3/news/2273321/smartphones-nokia-n8-symbian">Nokia N8 hit by power down problems</A></DIV><DIV CLASS="lnkr"><CITE>Matthew Humphries / <A HREF="http://www.geek.com/">Geek.com</A>:</CITE> &nbsp; <A HREF="http://www.geek.com/articles/mobile/nokia-admits-some-n8-smartphones-are-dying-20101118/">Nokia admits some N8 smartphones are dying</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.softpedia.com/">Softpedia News</A>:</CITE> &nbsp; <A HREF="http://news.softpedia.com/news/Nokia-Admits-to-N8-Power-Management-Issues-167436.shtml">Nokia Admits to N8 Power Management Issues</A></DIV><DIV CLASS="lnkr"><CITE>Adam Mills / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/mobile/2010/11/18/nokia-confirms-n8-power-management-issue/">Nokia Confirms N8 &lsquo;Power Management&rsquo; Issue</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.electronista.com/">Electronista</A>:</CITE> &nbsp; <A HREF="http://www.electronista.com/articles/10/11/18/nokia.says.n8.plagued.by.power.issue.c7.likely/">Nokia confirms N8s hit by major power bug; C7 also affected</A></DIV><DIV CLASS="lnkr"><CITE>Zach Epstein / <A HREF="http://www.bgr.com/">BGR</A>:</CITE> &nbsp; <A HREF="http://www.bgr.com/2010/11/18/nokia-some-n8-units-have-a-power-management-issue/">Nokia: some N8 units have a &lsquo;power management&rsquo; issue</A></DIV><DIV CLASS="lnkr"><CITE>Scott Bicheno / <A HREF="http://channel.hexus.net/">HEXUS.channel</A>:</CITE> &nbsp; <A HREF="http://channel.hexus.net/content/item.php?item=27590">Nokia speaks-out about N8 power problems</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.ubergizmo.com/">Ubergizmo</A>:</CITE> &nbsp; <A HREF="http://www.ubergizmo.com/15/archives/2010/11/failing_nokia_n8_suffering_from_faulty_parts.html">Failing Nokia N8 Suffering from Faulty Parts?</A></DIV><DIV CLASS="lnkr"><CITE>Todd Haselton / <A HREF="http://www.mobileburn.com/">MobileBurn.com</A>:</CITE> &nbsp; <A HREF="http://www.mobileburn.com/news.jsp?Id=11760">Nokia says some N8 smartphones have faulty power management issue</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p5"></A>
+<DIV CLASS="item" ID="101119p5" ONMOUSEOVER="nnid('22dx1')">
+<A HREF="http://www.bing.com/community/site_blogs/b/maps/archive/2010/11/18/announcing-the-new-bing-maps-site-with-a-redesigned-left_2d00_rail-and-broader-access-to-map-apps-_2600_-streetside.aspx"><IMG CLASS="ill" SRC="/101119/i5.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p5#a101119p5" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s25');
+--></script>
+<CITE>Brian Hendricks / <A HREF="http://www.bing.com/">Bing</A>:</CITE>
+<span id="s25" pml="101119p5" spml="AJV5" bitly="cUX4iJ" url="http://www.bing.com/community/site_blogs/b/maps/archive/2010/11/18/announcing-the-new-bing-maps-site-with-a-redesigned-left_2d00_rail-and-broader-access-to-map-apps-_2600_-streetside.aspx" head="Announcing the new Bing Maps site with a redesigned left-rail ... (@brianhen / Bing)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://www.bing.com/community/site_blogs/b/maps/archive/2010/11/18/announcing-the-new-bing-maps-site-with-a-redesigned-left_2d00_rail-and-broader-access-to-map-apps-_2600_-streetside.aspx">Announcing the new Bing Maps site with a redesigned left-rail and broader access to Map Apps &amp; StreetSide</A></STRONG>&nbsp; &mdash;&nbsp; Today, we're happy to announce the following additions and changes to Bing Maps:&nbsp; &mdash;&nbsp; AJAX V7 Control&nbsp; &mdash;&nbsp; The launch of the next version the Bing Maps AJAX control provides consumers &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.bing.com/community/site_blogs/b/maps/archive/2010/11/18/announcing-the-new-bing-maps-site-with-a-redesigned-left_2d00_rail-and-broader-access-to-map-apps-_2600_-streetside.aspx');
+--></SCRIPT>
+<DIV ID="22d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('22dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="22dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('22',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.liveside.net/2010/11/18/another-new-look-for-bing-maps/">LiveSide.net</A>, <A HREF="http://blogs.msdn.com/b/keithkin/archive/2010/11/18/bing-maps-ajax-control-v7-hello-world-sample.aspx">MSDN Blogs</A>, <A HREF="http://news.softpedia.com/news/Bing-Maps-Redesign-Introduced-167572.shtml">Softpedia News</A>, <A HREF="http://searchengineland.com/bing-maps-overhauls-interface-exposes-map-apps-to-all-56415">Search Engine Land</A>, <A HREF="http://thenextweb.com/microsoft/2010/11/19/bing-we-still-love-and-use-silverlight/">The Next Web</A> and <A HREF="http://www.winrumors.com/bing-maps-introduces-mobile-html5-support-and-updated-ajax-control/">Winrumors</A></SPAN>
+</DIV></DIV>
+<DIV ID="22p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="22px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('22',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Kip Kniskern / <A HREF="http://www.liveside.net/">LiveSide.net</A>:</CITE> &nbsp; <A HREF="http://www.liveside.net/2010/11/18/another-new-look-for-bing-maps/">Another new look for Bing Maps</A></DIV><DIV CLASS="lnkr"><CITE>Keithkin / <A HREF="http://blogs.msdn.com/b/">MSDN Blogs</A>:</CITE> &nbsp; <A HREF="http://blogs.msdn.com/b/keithkin/archive/2010/11/18/bing-maps-ajax-control-v7-hello-world-sample.aspx">Bing Maps Ajax Control v7 - Hello World Sample</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.softpedia.com/">Softpedia News</A>:</CITE> &nbsp; <A HREF="http://news.softpedia.com/news/Bing-Maps-Redesign-Introduced-167572.shtml">Bing Maps Redesign Introduced</A></DIV><DIV CLASS="lnkr"><CITE>Matt McGee / <A HREF="http://searchengineland.com/">Search Engine Land</A>:</CITE> &nbsp; <A HREF="http://searchengineland.com/bing-maps-overhauls-interface-exposes-map-apps-to-all-56415">Bing Maps Overhauls Interface, Exposes Map Apps To All</A></DIV><DIV CLASS="lnkr"><CITE>Alex Wilhelm / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/microsoft/2010/11/19/bing-we-still-love-and-use-silverlight/">Bing: We still love and use Silverlight!</A></DIV><DIV CLASS="lnkr"><CITE>Tom Warren / <A HREF="http://www.winrumors.com/">Winrumors</A>:</CITE> &nbsp; <A HREF="http://www.winrumors.com/bing-maps-introduces-mobile-html5-support-and-updated-ajax-control/">Bing Maps introduces mobile HTML5 support and updated AJAX control</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="rsp">
+<DIV CLASS="item">
+<A HREF="/goto/channel9.msdn.com/"><IMG CLASS="sill" SRC="/simg/9guy.png"></A>
+<CITE><A HREF="/goto/channel9.msdn.com/">Channel 9</A>:</CITE>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="/goto/channel9.msdn.com/Shows/The+Knowledge+Chamber/Using-XNA-for-Developing-Windows-Phone-Games">Using XNA for Developing Windows Phone Games</A></STRONG>&nbsp; &mdash;&nbsp; When talking about developing applications for the new Windows Phone platform, we usually focus on Silverlight.&nbsp; There is, however, another programming model for developing Windows Phone applications, and that's XNA&mdash;a special programming model based &hellip; </DIV>
+</DIV>
+<DIV CLASS="rspd">Recent Sponsor Post</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101118p77"></A>
+<DIV CLASS="item" ID="101118p77" ONMOUSEOVER="nnid('23dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p77#a101118p77" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s26');
+--></script>
+<CITE>Martyn Daniels / <A HREF="http://bookseller-association.blogspot.com/">Brave New World</A>:</CITE>
+<span id="s26" pml="101118p77" spml="AJGC" bitly="cZgqxY" url="http://bookseller-association.blogspot.com/2010/11/amazon-is-becoming-true-publishing.html" head="Amazon is Becoming the True Publishing Vertical Business (@danielsm1 / Brave New World)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://bookseller-association.blogspot.com/2010/11/amazon-is-becoming-true-publishing.html">Amazon is Becoming the True Publishing Vertical Business</A></STRONG>&nbsp; &mdash;&nbsp; So you think you know what Amazon is but think again as the global brand makes more media moves which although small show just how savvy the organisations.&nbsp; &mdash;&nbsp; The first announcement that Amazon.com is launching Amazon Studios.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://bookseller-association.blogspot.com/2010/11/amazon-is-becoming-true-publishing.html');
+--></SCRIPT>
+<DIV ID="23d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('23dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="23dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('23',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://econsultancy.com/us/blog/6866-will-amazon-move-aggressively-into-content">the Econsultancy blog</A></SPAN>
+</DIV></DIV>
+<DIV ID="23p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="23px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('23',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Patricio Robles / <A HREF="http://econsultancy.com/us/blog">the Econsultancy blog</A>:</CITE> &nbsp; <A HREF="http://econsultancy.com/us/blog/6866-will-amazon-move-aggressively-into-content">Will Amazon move aggressively into content?</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101119p12"></A>
+<DIV CLASS="item" ID="101119p12" ONMOUSEOVER="nnid('24dx1')">
+<A HREF="http://online.wsj.com/article/SB10001424052748704104104575622080860055498.html"><IMG CLASS="ill" SRC="/101119/i12.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p12#a101119p12" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s27');
+--></script>
+<CITE>Rebecca Mackinnon / <A HREF="http://online.wsj.com/public/us">Wall Street Journal</A>:</CITE>
+<span id="s27" pml="101119p12" spml="AJVB" bitly="aChelS" url="http://online.wsj.com/article/SB10001424052748704104104575622080860055498.html" head="No Quick Fixes for Internet Freedom (@rmack / Wall Street Journal)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://online.wsj.com/article/SB10001424052748704104104575622080860055498.html">No Quick Fixes for Internet Freedom</A></STRONG>&nbsp; &mdash;&nbsp; The hard work to promote free speech online has barely begun.&nbsp; &mdash;&nbsp; Just before U.S. Secretary of State Hillary Clinton arrived in Hanoi late last month, Vietnamese authorities redoubled their assault on Internet dissent.</DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://online.wsj.com/article/SB10001424052748704104104575622080860055498.html');
+--></SCRIPT>
+<DIV ID="24d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('24dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="24dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('24',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://opennet.net/newsreel">ONI</A></SPAN>
+</DIV></DIV>
+<DIV ID="24p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="24px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('24',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE><A HREF="http://opennet.net/">ONI</A>:</CITE> &nbsp; <A HREF="http://opennet.net/newsreel">Syrian bloggers brace for fresh blow to Middle East press freedom</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clus">
+<A NAME="a101118p76"></A>
+<DIV CLASS="item" ID="101118p76" ONMOUSEOVER="nnid()">
+<A HREF="http://blogs.forbes.com/oliverchiang/2010/11/18/exclusive-youweb-billion-dollar-incubator/"><IMG CLASS="ill" SRC="/101118/i76.jpg"></A>
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p76#a101118p76" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s28');
+--></script>
+<CITE>Oliver Chiang / <A HREF="http://blogs.forbes.com/oliverchiang">SelectStart</A>:</CITE>
+<span id="s28" pml="101118p76" spml="AJGB" bitly="aQwnK7" url="http://blogs.forbes.com/oliverchiang/2010/11/18/exclusive-youweb-billion-dollar-incubator/" head="Exclusive: YouWeb, Billion-Dollar Incubator? (@ojchiang / SelectStart)" class="sharebox" style="display:none;"></span>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="http://blogs.forbes.com/oliverchiang/2010/11/18/exclusive-youweb-billion-dollar-incubator/">Exclusive: YouWeb, Billion-Dollar Incubator?</A></STRONG>&nbsp; &mdash;&nbsp; Even in the insular echo chamber of Silicon Valley, the name YouWeb doesn't come up a whole lot.&nbsp; Yet the young incubator, largely a one-man show run by founder Peter Relan, has in just three years taken its initial seed capital of $700,000 &hellip; </DIV>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://blogs.forbes.com/oliverchiang/2010/11/18/exclusive-youweb-billion-dollar-incubator/');
+--></SCRIPT>
+</DIV>
+</DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="rpan">
+<DIV CLASS="padlr">
+<DIV ID="aboutbox" STYLE="display: none">
+<DIV CLASS="aboutrn">
+<DIV CLASS="rncont">
+<DIV CLASS="rnhdbak">
+<SPAN CLASS="rnhd1">&nbsp;</SPAN><SPAN CLASS="rnhd2">About Techmeme:</SPAN><SPAN CLASS="rnhd3">&nbsp;</SPAN>
+</DIV>
+<DIV CLASS="rnbody">
+<P>At this moment, the must-read stories in technology
+are scattered across hundreds of news sites and blogs.
+That's far too much for any reader to follow.</P>
+<P>Fortunately, Techmeme arranges all of these links
+into a single, easy-to-scan page.
+Story selection is accomplished via computer algorithm
+extended with direct human editorial input.</P>
+<P>Our goal is for Techmeme to become
+your tech news site of record.</P>
+<DIV STYLE="padding: 1.5em 0 0 1em;">
+<SCRIPT TYPE="text/javascript">
+<!--
+var ea='s@t';ea='uestionsorcomment'+ea+'echmeme.com';ea='q'+ea;
+document.write('Send questions or comments (no mailing lists or press releases please) to <A HREF="mai'+'lto:'+ea+'">'+ea+'</A>');
+//-->
+</SCRIPT>
+</DIV>
+<DIV STYLE="text-align:right"><A HREF="javascript:td('aboutbox')">&laquo; Close</A></DIV>
+</DIV>
+<DIV CLASS="rnftbak">&nbsp;</DIV>
+</DIV>
+</DIV>
+</DIV>
+
+<DIV CLASS="col0rn">
+<DIV CLASS="rncont">
+<DIV CLASS="rnhdbak">
+<SPAN CLASS="rnhd1">&nbsp;</SPAN><SPAN CLASS="rnhd2">New Item Finder:</SPAN><SPAN CLASS="rnhd3">&nbsp;</SPAN>
+</DIV>
+<DIV CLASS="rnbody">
+<DIV CLASS="upd">
+<DIV CLASS="heditem"><DIV CLASS="ago">5&nbsp;minutes&nbsp;ago</DIV>
+<CITE>John Paczkowski / Digital Daily:</CITE><BR>
+<A CLASS="nfdl" HREF="http://digitaldaily.allthingsd.com/20101119/apple-developing-cdma-gsm-world-ipad/">Apple Developing CDMA-GSM &lsquo;World iPad&rsquo;?</A> &nbsp; <A HREF="#a101119p26" onclick="h('101119p26');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">20&nbsp;minutes&nbsp;ago</DIV>
+<CITE>Henry Blodget / SAI:</CITE><BR>
+<A CLASS="nfdl" HREF="http://www.businessinsider.com/google-buy-groupon-and-twitter-and-foursquare-2010-11">Hell, Yes, Google Should Buy Groupon. And Twitter. And Foursquare...</A> &nbsp; <A HREF="#a101119p25" onclick="h('101119p25');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">30&nbsp;minutes&nbsp;ago</DIV>
+<CITE>Electronista:</CITE><BR>
+<A CLASS="nfdl" HREF="http://www.electronista.com/articles/10/11/18/euro.carriers.warn.apple.over.embedded.sims/">Carriers threaten Apple over talk of embedded iPhone SIMs</A> &nbsp; <A HREF="#a101119p24" onclick="h('101119p24');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">40&nbsp;minutes&nbsp;ago</DIV>
+<CITE>Michael Grothaus / TUAW:</CITE><BR>
+<A CLASS="nfdl" HREF="http://www.tuaw.com/2010/11/19/mac-os-x-10-6-5-fixes-macbook-air-display-issues/">Mac OS X 10.6.5 fixes MacBook Air display issues</A> &nbsp; <A HREF="#a101119p23" onclick="h('101119p23');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">70&nbsp;minutes&nbsp;ago</DIV>
+<CITE>Kara Swisher / BoomTown:</CITE><BR>
+<A CLASS="nfdl" HREF="http://kara.allthingsd.com/20101119/google-turns-its-local-eyes-to-groupon-but-who-else-could-enter-bidding/">Google Turns Its Local Eyes to Groupon-But Who Else Could Enter Bidding?</A> &nbsp; <A HREF="#a101119p22" onclick="h('101119p22');return true;">Find</A>
+</DIV>
+<DIV ID="show_more_new" STYLE="text-align:right"><A HREF="javascript:smn()">&raquo; Extend timeline</A></DIV>
+<DIV ID="more_new" STYLE="display: none;">
+<DIV CLASS="heditem"><DIV CLASS="ago">1&frac12;&nbsp;hours&nbsp;ago</DIV>
+<CITE>Tim Berners-Lee / Scientific American:</CITE><BR>
+<A CLASS="nfdl" HREF="http://www.scientificamerican.com/article.cfm?id=long-live-the-web">Long Live the Web</A> &nbsp; <A HREF="#a101119p21" onclick="h('101119p21');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">1&frac12;&nbsp;hours&nbsp;ago</DIV>
+<CITE>Josh Halliday / Guardian:</CITE><BR>
+<A CLASS="nfdl" HREF="http://www.guardian.co.uk/technology/2010/nov/19/google-street-view-data">Google to delete Street View data gathered in the UK</A> &nbsp; <A HREF="#a101119p20" onclick="h('101119p20');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">2&nbsp;hours&nbsp;ago</DIV>
+<CITE>Shayndi Raice / Wall Street Journal:</CITE><BR>
+<A CLASS="nfdl" HREF="http://online.wsj.com/article/SB10001424052748703374304575622884122938068.html">Small Deal Brings Scrutiny to Huawei</A> &nbsp; <A HREF="#a101119p19" onclick="h('101119p19');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">2&frac12;&nbsp;hours&nbsp;ago</DIV>
+<CITE>Klint Finley / ReadWriteWeb:</CITE><BR>
+<A CLASS="nfdl" HREF="http://www.readwriteweb.com/cloud/2010/11/salesforcecoms-chatter-to-go-f.php">Salesforce.com's Chatter to Go Freemium</A> &nbsp; <A HREF="#a101119p18" onclick="h('101119p18');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">3&nbsp;hours&nbsp;ago</DIV>
+<CITE>Ingrid Lee / DigiTimes:</CITE><BR>
+<A CLASS="nfdl" HREF="http://www.digitimes.com/news/a20101118PD211.html">Sources reveal some PCB suppliers for iPad 2</A> &nbsp; <A HREF="#a101119p16" onclick="h('101119p16');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">3&frac12;&nbsp;hours&nbsp;ago</DIV>
+<CITE>Phil / Nokia Conversations:</CITE><BR>
+<A CLASS="nfdl" HREF="http://conversations.nokia.com/2010/11/18/evp-niklas-savander-discusses-nokia-n8-quality/">EVP Niklas Savander discusses Nokia N8 quality</A> &nbsp; <A HREF="#a101119p15" onclick="h('101119p15');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">4&nbsp;hours&nbsp;ago</DIV>
+<CITE>Mark Milian / CNN:</CITE><BR>
+<A CLASS="nfdl" HREF="http://edition.cnn.com/2010/TECH/social.media/11/19/twitter.china/">Twitter CEO chides China</A> &nbsp; <A HREF="#a101119p14" onclick="h('101119p14');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">4&frac12;&nbsp;hours&nbsp;ago</DIV>
+<CITE>Phil Nickinson / Android Central:</CITE><BR>
+<A CLASS="nfdl" HREF="http://www.androidcentral.com/htc-merge-360-degree-view-appears-quickly-disappears-verizons-site">HTC Merge 360-degree view appears, quickly disappears from Verizon's site</A> &nbsp; <A HREF="#a101119p13" onclick="h('101119p13');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">5&frac12;&nbsp;hours&nbsp;ago</DIV>
+<CITE>Rebecca Mackinnon / Wall Street Journal:</CITE><BR>
+<A CLASS="nfdl" HREF="http://online.wsj.com/article/SB10001424052748704104104575622080860055498.html">No Quick Fixes for Internet Freedom</A> &nbsp; <A HREF="#a101119p12" onclick="h('101119p12');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">6&nbsp;hours&nbsp;ago</DIV>
+<CITE>Andreas Tuerk / Google LatLong:</CITE><BR>
+<A CLASS="nfdl" HREF="http://google-latlong.blogspot.com/2010/11/street-view-comes-to-20-german-cities.html">Street View comes to 20 German cities</A> &nbsp; <A HREF="#a101119p11" onclick="h('101119p11');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">7&nbsp;hours&nbsp;ago</DIV>
+<CITE>Tana Ganeva / AlterNet:</CITE><BR>
+<A CLASS="nfdl" HREF="http://www.alternet.org/newsandviews/article/337982/debt_collectors_stalking,_publicly_shaming_people_through_facebook/">Debt Collectors Stalking, Publicly Shaming People Through Facebook</A> &nbsp; <A HREF="#a101119p10" onclick="h('101119p10');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">8&nbsp;hours&nbsp;ago</DIV>
+<CITE>Seth Weintraub / 9 to 5 Mac:</CITE><BR>
+<A CLASS="nfdl" HREF="http://www.9to5mac.com/36541/mac-store-opening-soon-apple-implores-developers-to-submit-their-apps">Mac App Store opening soon, Apple implores developers to submit their apps</A> &nbsp; <A HREF="#a101119p9" onclick="h('101119p9');return true;">Find</A>
+</DIV>
+<DIV CLASS="heditem"><DIV CLASS="ago">10&nbsp;hours&nbsp;ago</DIV>
+<CITE>Jason Kincaid / TechCrunch:</CITE><BR>
+<A CLASS="nfdl" HREF="http://techcrunch.com/2010/11/18/scribd-stats-a-google-analytics-for-documents/">Scribd Stats: A &lsquo;Google Analytics For Documents&rsquo;</A> &nbsp; <A HREF="#a101119p8" onclick="h('101119p8');return true;">Find</A>
+</DIV>
+<BR>
+<DIV STYLE="float:right;padding-left:1em;">
+<A HREF="javascript:hmn()">&laquo; Reduce timeline</A>
+</DIV>
+<A HREF="http://www.techmeme.com/river">&raquo; Techmeme River</A>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="rnftbak">&nbsp;</DIV>
+</DIV>
+</DIV>
+
+<DIV CLASS="sponrn">
+<DIV CLASS="rncont">
+<DIV CLASS="rnhdbak">
+<SPAN CLASS="rnhd1">&nbsp;</SPAN><SPAN CLASS="rnhd2">Techmeme Sponsor Posts:</SPAN><SPAN CLASS="rnhd3">&nbsp;</SPAN>
+</DIV>
+<DIV CLASS="rnbody">
+<DIV CLASS="sitems">
+<DIV CLASS="item">
+<A HREF="/goto/www.microsoftstartupzone.com/"><IMG CLASS="sill" SRC="/simg/bizspark.jpg"></A>
+<CITE><A HREF="/goto/www.microsoftstartupzone.com/">Microsoft BizSpark</A>:</CITE>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="/goto/www.bizspark.com/Blogs/globalstartups/Lists/Posts/ViewPost.aspx?ID=22">Postcard from Paris: Windows 7 phone driving innovation with tech start-ups &amp; developers</A></STRONG>&nbsp; &mdash;&nbsp; by Blaise Vignon, Emerging Business Team Lead, France&nbsp; &mdash;&nbsp; When Steve Ballmer visited Microsoft's French HQ in Paris a few weeks ago &hellip; </DIV>
+</DIV>
+<DIV CLASS="item">
+<A HREF="/goto/channel9.msdn.com/"><IMG CLASS="sill" SRC="/simg/9guy.png"></A>
+<CITE><A HREF="/goto/channel9.msdn.com/">Channel 9</A>:</CITE>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="/goto/channel9.msdn.com/Shows/The+Knowledge+Chamber/Using-XNA-for-Developing-Windows-Phone-Games">Using XNA for Developing Windows Phone Games</A></STRONG>&nbsp; &mdash;&nbsp; When talking about developing applications for the new Windows Phone platform, we usually focus on Silverlight.&nbsp; There is, however, another programming model &hellip; </DIV>
+</DIV>
+<DIV CLASS="item">
+<A HREF="/goto/backupify.com/"><IMG CLASS="sill" SRC="/simg/backupify.jpg"></A>
+<CITE><A HREF="/goto/blog.backupify.com/">Backupify</A>:</CITE>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="/goto/blog.backupify.com/2010/11/09/backupify-releases-first-ever-independent-backup-solution-for-facebook-fan-pages/">Backupify Releases First-Ever Independent Backup Solution for Facebook Fan Pages</A></STRONG>&nbsp; &mdash;&nbsp; While the summer months were certainly busy for the Backupify team&mdash;the launch of our Google Apps service &hellip; </DIV>
+</DIV>
+<DIV CLASS="item">
+<A HREF="/goto/softwarecommunity.intel.com/"><IMG CLASS="sill" SRC="/simg/isn.jpg"></A>
+<CITE><A HREF="/goto/software.intel.com/en-us/blogs">Intel Software Network Blogs</A>:</CITE>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="/goto/appdeveloper.intel.com/en-us/blog/2010/11/18/netbooks-everywhere-airport-classroom-powering-music-behind-fun-run">Netbooks everywhere, in the classroom, powering the music behind the fun run!</A></STRONG>&nbsp; &mdash;&nbsp; My two oldest daughters attend a local public elementary school in Oregon.&nbsp; During the back to school night our teacher presented &hellip; </DIV>
+</DIV>
+<DIV CLASS="item">
+<A HREF="/goto/googlemobile.blogspot.com/2010/11/google-sky-map-now-with-time-travel.html?utm_source=tcm&utm_medium=ttl&utm_campaign=gmb"><IMG CLASS="sill" SRC="/simg/google75.png"></A>
+<CITE><A HREF="/goto/googlemobile.blogspot.com/?utm_source=tcm&utm_medium=ttl&utm_campaign=gmb">Google Mobile Blog</A>:</CITE>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="/goto/googlemobile.blogspot.com/2010/11/google-sky-map-now-with-time-travel.html?utm_source=tcm&utm_medium=ttl&utm_campaign=gmb">Google Sky Map- now with time travel</A></STRONG>&nbsp; &mdash;&nbsp; Man ... can go up against gravitation in a balloon, and why should he not hope that ultimately he may be able to stop or accelerate his drift along the Time-Dimension, or even turn about and travel the other way.</DIV>
+</DIV>
+<DIV CLASS="item">
+<A HREF="/goto/seesmic.com/"><IMG CLASS="sill" SRC="/simg/seesmic.png"></A>
+<CITE><A HREF="/goto/blog.seesmic.com/">Seesmic Blog</A>:</CITE>
+<DIV CLASS="ii"><STRONG CLASS="L1"><A HREF="/goto/blog.seesmic.com/2010/11/seesmic-continues-its-salesforce-world-tour-with-paris-this-week.html">Seesmic continues its Salesforce World Tour in Paris this week</A></STRONG>&nbsp; &mdash;&nbsp; Packed Seesmic booth and keynote room for our demo of Salesforce Chatter integration in Seesmic Desktop, Web and Android in Paris this week.</DIV>
+</DIV>
+</DIV>
+<CENTER>
+<A HREF="/sponsor">Sponsor Techmeme</A>
+</CENTER>
+</DIV>
+<DIV CLASS="rnftbak">&nbsp;</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="col1rn">
+<DIV CLASS="rncont">
+<DIV CLASS="rnhdbak">
+<SPAN CLASS="rnhd1">&nbsp;</SPAN><SPAN CLASS="rnhd2">Site News:</SPAN><SPAN CLASS="rnhd3">&nbsp;</SPAN>
+</DIV>
+<DIV CLASS="rnbody">
+<P>Nothing recent. See <A HREF="http://news.techmeme.com/">Techmeme News</A> for earlier news.</P>
+</DIV>
+<DIV CLASS="rnftbak">&nbsp;</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="col0rn">
+<DIV CLASS="rncont">
+<DIV CLASS="rnhdbak">
+<SPAN CLASS="rnhd1">&nbsp;</SPAN><SPAN CLASS="rnhd2">See Also:</SPAN><SPAN CLASS="rnhd3">&nbsp;</SPAN>
+</DIV>
+<DIV CLASS="rnbody">
+<div class="snh"><a href="http://www.techmeme.com/river">Techmeme River</a>: reverse chronological Techmeme</div>
+<div class="snh"><a href="http://www.techmeme.com/m">Techmeme Mobile</a>: for modern smartphones</div>
+<div class="snh"><a href="http://www.techmeme.com/mini">Mini-Techmeme</a>: for simple mobiles</div>
+<div class="snh"><a href="http://www.techmeme.com/lb">Techmeme Leaderboard</a>: Techmeme's top sources</div>
+</DIV>
+<DIV CLASS="rnftbak">&nbsp;</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="col1rn">
+<DIV CLASS="rncont">
+<DIV CLASS="rnhdbak">
+<SPAN CLASS="rnhd1">&nbsp;</SPAN><SPAN CLASS="rnhd2">Subscribe:</SPAN><SPAN CLASS="rnhd3">&nbsp;</SPAN>
+</DIV>
+<DIV CLASS="rnbody">
+<FORM NAME="subsform">
+Add Techmeme to: <select name="aggs">
+<OPTION VALUE="http://fusion.google.com/add?feedurl=http://www.techmeme.com/index.xml">Google</OPTION>
+<OPTION VALUE="http://add.my.yahoo.com/rss?url=http://www.techmeme.com/index.xml">My Yahoo!</OPTION>
+<OPTION VALUE="http://www.newsgator.com/ngs/subscriber/subext.aspx?url=http://www.techmeme.com/index.xml">Newsgator</OPTION>
+<OPTION VALUE="http://www.netvibes.com/subscribe.php?url=http://www.techmeme.com/index.xml">Netvibes</OPTION>
+<OPTION VALUE="http://www.live.com/?add=http://www.techmeme.com/index.xml">Windows Live</OPTION>
+<OPTION VALUE="http://www.pageflakes.com/subscribe.aspx?url=http://www.techmeme.com/index.xml">Pageflakes</OPTION>
+</select>
+<INPUT TYPE="button" ONCLICK="location=document.subsform.aggs.options[document.subsform.aggs.selectedIndex].value;" VALUE="Go">
+</FORM>
+<NOSCRIPT><B>Note:</B> First enable Javascript in your browser to use the above menu.<BR><BR></NOSCRIPT>
+<DIV STYLE="padding-top:1.2em;"><A HREF="http://www.techmeme.com/index.xml"><IMG SRC="/img/feed_icon.png"></A> Techmeme RSS feeds: &nbsp; <A HREF="http://www.techmeme.com/index.xml">Top Posts</A> &nbsp; <A HREF="http://www.techmeme.com/firehose.xml">All Posts (Firehose)</A></DIV>
+<DIV STYLE="padding-top:1.2em;"><A HREF="http://twitter.com/Techmeme"><IMG SRC="/img/twitter_icon.gif"></A> Techmeme on Twitter: &nbsp; <A HREF="http://twitter.com/Techmeme">Top Posts</A> &nbsp; <A HREF="http://twitter.com/TechmemeFH">All Posts (Firehose)</A></DIV>
+</DIV>
+<DIV CLASS="rnftbak">&nbsp;</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="col0rn">
+<DIV CLASS="rncont">
+<DIV CLASS="rnhdbak">
+<SPAN CLASS="rnhd1">&nbsp;</SPAN><SPAN CLASS="rnhd2">Archives:</SPAN><SPAN CLASS="rnhd3">&nbsp;</SPAN>
+</DIV>
+<DIV CLASS="rnbody">
+<SCRIPT SRC="/arbr.js" TYPE="text/javascript"></SCRIPT>
+</DIV>
+<DIV CLASS="rnftbak">&nbsp;</DIV>
+</DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clearfloats">&nbsp;</DIV>
+
+<DIV CLASS="halfcol">
+<DIV CLASS="padlr">
+<DIV CLASS="col0rn">
+<DIV CLASS="rncont">
+<DIV CLASS="rnhdbak">
+<SPAN CLASS="rnhd1">&nbsp;</SPAN><SPAN CLASS="rnhd2">More Items:</SPAN><SPAN CLASS="rnhd3">&nbsp;</SPAN>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="nornbody">
+<A NAME="a101119p11"></A>
+<DIV CLASS="heditem" ID="101119p11" ONMOUSEOVER="nnid('26dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p11#a101119p11" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s29');
+--></script>
+<CITE>Andreas Tuerk / <A HREF="http://google-latlong.blogspot.com/">Google LatLong</A>:</CITE>
+<span id="s29" pml="101119p11" spml="AJVA" bitly="ax9JWT" url="http://google-latlong.blogspot.com/2010/11/street-view-comes-to-20-german-cities.html" head="Street View comes to 20 German cities (Andreas Tuerk / Google LatLong)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://google-latlong.blogspot.com/2010/11/street-view-comes-to-20-german-cities.html">Street View comes to 20 German cities</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://google-latlong.blogspot.com/2010/11/street-view-comes-to-20-german-cities.html');
+--></SCRIPT>
+<DIV ID="26d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('26dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="26dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('26',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://news.idg.no/cw/art.cfm?id=648397AE-1A64-6A71-CE20A9E83BD7EF9A">Computerworld</A>, <A HREF="http://www.theregister.co.uk/2010/11/19/street_view_germany/">The Register</A>, <A HREF="http://www.spiegel.de/international/business/0,1518,729793,00.html">Spiegel Online</A>, <A HREF="http://news.softpedia.com/news/Google-Street-View-Now-Available-in-20-Major-German-Cities-167481.shtml">Softpedia News</A>, <A HREF="http://www.readwriteweb.com/archives/googles_street_view_germany_expands_to_20_more_cit.php">ReadWriteWeb</A>, <A HREF="http://thenextweb.com/google/2010/11/19/googles-new-street-view-privacy-policy-apparently-extends-to-their-offices-too/">The Next Web</A>, <A HREF="http://www.centernetworks.com/google-maps-street-view-germany">CenterNetworks</A> and <A HREF="http://news.cnet.com/8301-17852_3-20023292-71.html">Technically Incorrect</A></SPAN>
+</DIV></DIV>
+<DIV ID="26p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="26px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('26',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Jeremy Kirk / <A HREF="http://computerworld.com/">Computerworld</A>:</CITE> &nbsp; <A HREF="http://news.idg.no/cw/art.cfm?id=648397AE-1A64-6A71-CE20A9E83BD7EF9A">Google fixes Street View as German launch continues</A></DIV><DIV CLASS="lnkr"><CITE>Lester Haines / <A HREF="http://www.theregister.co.uk/">The Register</A>:</CITE> &nbsp; <A HREF="http://www.theregister.co.uk/2010/11/19/street_view_germany/">Street View hits 20 German cities</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://service.spiegel.de/cache/international">Spiegel Online</A>:</CITE> &nbsp; <A HREF="http://www.spiegel.de/international/business/0,1518,729793,00.html">Google Launches Street View Germany</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.softpedia.com/">Softpedia News</A>:</CITE> &nbsp; <A HREF="http://news.softpedia.com/news/Google-Street-View-Now-Available-in-20-Major-German-Cities-167481.shtml">Google Street View Now Available in 20 Major German Cities</A></DIV><DIV CLASS="lnkr"><CITE>Frederic Lardinois / <A HREF="http://www.readwriteweb.com/">ReadWriteWeb</A>:</CITE> &nbsp; <A HREF="http://www.readwriteweb.com/archives/googles_street_view_germany_expands_to_20_more_cit.php">Google Faces More Resistance in Germany as Street View Expands to More Cities</A></DIV><DIV CLASS="lnkr"><CITE>Adam Mills / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/google/2010/11/19/googles-new-street-view-privacy-policy-apparently-extends-to-their-offices-too/">Google's new Street View privacy policy apparently extends to their offices too</A></DIV><DIV CLASS="lnkr"><CITE>Allen Stern / <A HREF="http://www.centernetworks.com/">CenterNetworks</A>:</CITE> &nbsp; <A HREF="http://www.centernetworks.com/google-maps-street-view-germany">Google Maps Blurry Street View Available in 20 German Cities</A></DIV><DIV CLASS="lnkr"><CITE>Chris Matyszczyk / <A HREF="http://news.cnet.com/technically-incorrect/">Technically Incorrect</A>:</CITE> &nbsp; <A HREF="http://news.cnet.com/8301-17852_3-20023292-71.html">Google's own office blurred out on Street View</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101119p8"></A>
+<DIV CLASS="heditem" ID="101119p8" ONMOUSEOVER="nnid('27dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p8#a101119p8" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s30');
+--></script>
+<CITE>Jason Kincaid / <A HREF="http://techcrunch.com/">TechCrunch</A>:</CITE>
+<span id="s30" pml="101119p8" spml="AJV8" bitly="bhTtGO" url="http://techcrunch.com/2010/11/18/scribd-stats-a-google-analytics-for-documents/" head="Scribd Stats: A 'Google Analytics For Documents' (@jasonkincaid / TechCrunch)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://techcrunch.com/2010/11/18/scribd-stats-a-google-analytics-for-documents/">Scribd Stats: A &lsquo;Google Analytics For Documents&rsquo;</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://techcrunch.com/2010/11/18/scribd-stats-a-google-analytics-for-documents/');
+--></SCRIPT>
+<DIV ID="27d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('27dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="27dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('27',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.fastcompany.com/1703868/could-scribd-stats-change-the-way-we-write">Fast Company</A> and <A HREF="http://www.readwriteweb.com/archives/analytics_for_your_docs_with_scribd_stats.php">ReadWriteWeb</A></SPAN>
+</DIV></DIV>
+<DIV ID="27p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="27px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('27',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>E.B. Boyd / <A HREF="http://www.fastcompany.com/">Fast Company</A>:</CITE> &nbsp; <A HREF="http://www.fastcompany.com/1703868/could-scribd-stats-change-the-way-we-write">Could Scribd Stats Change the Way We Write?</A></DIV><DIV CLASS="lnkr"><CITE>Audrey Watters / <A HREF="http://www.readwriteweb.com/">ReadWriteWeb</A>:</CITE> &nbsp; <A HREF="http://www.readwriteweb.com/archives/analytics_for_your_docs_with_scribd_stats.php">Analytics for Your Docs with Scribd Stats</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101119p2"></A>
+<DIV CLASS="heditem" ID="101119p2" ONMOUSEOVER="nnid('28dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101119/p2#a101119p2" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s31');
+--></script>
+<CITE>Ashlee Vance / <A HREF="http://www.nytimes.com/pages/technology/">New York Times</A>:</CITE>
+<span id="s31" pml="101119p2" spml="AJV2" bitly="aLGjGM" url="http://www.nytimes.com/2010/11/19/technology/19docs.html?partner=rss&emc=rss" head="An Unsealed Lawsuit Indicates Dell Hid Faults of Computers (@valleyhack / New York Times)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://www.nytimes.com/2010/11/19/technology/19docs.html?partner=rss&emc=rss">An Unsealed Lawsuit Indicates Dell Hid Faults of Computers</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.nytimes.com/2010/11/19/technology/19docs.html');
+--></SCRIPT>
+<DIV ID="28d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('28dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="28dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('28',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://247wallst.com/2010/11/19/dell-bad-business-practices-trump-earnings/">24/7 Wall St.</A></SPAN>
+</DIV></DIV>
+<DIV ID="28p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="28px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('28',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE><A HREF="http://247wallst.com/">24/7 Wall St.</A>:</CITE> &nbsp; <A HREF="http://247wallst.com/2010/11/19/dell-bad-business-practices-trump-earnings/">Dell: Bad Business Practices Trump Earnings</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p74"></A>
+<DIV CLASS="heditem" ID="101118p74" ONMOUSEOVER="nnid('29dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p74#a101118p74" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s32');
+--></script>
+<CITE>Gregg Keizer / <A HREF="http://computerworld.com/">Computerworld</A>:</CITE>
+<span id="s32" pml="101118p74" spml="AJG=" bitly="bqzDys" url="http://www.computerworld.com/s/article/9197230/Adobe_launches_sandboxed_Reader_X" head="Adobe launches 'sandboxed' Reader X (@gkeizer / Computerworld)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://www.computerworld.com/s/article/9197230/Adobe_launches_sandboxed_Reader_X">Adobe launches &lsquo;sandboxed&rsquo; Reader X</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.computerworld.com/s/article/9197230/Adobe_launches_sandboxed_Reader_X');
+--></SCRIPT>
+<DIV ID="29d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('29dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="29dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('29',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.pcworld.com/article/211150/">PC World</A>, <A HREF="http://blogs.adobe.com/asset/2010/11/adobe-reader-x-is-here.html">Adobe Secure Software &hellip;</A>, <A HREF="http://www.ghacks.net/2010/11/19/adobe-reader-x-download-available/">gHacks Technology News</A>, <A HREF="http://www.downloadsquad.com/2010/11/19/adobe-reader-x-for-android-and-desktop-available-now/">Download Squad</A>, <A HREF="http://www.labnol.org/software/adobe-reader-with-file-sharing/18209/">Digital Inspiration &hellip;</A>, <A HREF="http://www.theinquirer.net/inquirer/news/1899227/adobe-ring-fences-pdf-reader?WT.rss_f=News&WT.rss_a=Adobe+ring-fences+its+PDF+Reader">Inquirer</A>, <A HREF="http://threatpost.com/en_us/blogs/adobe-releases-reader-x-sandbox-111810">Dennis Fisher</A> and <A HREF="http://www.v3.co.uk/v3/news/2273313/adobe-reader-pdf-sandbox">V3.co.uk</A></SPAN>
+</DIV></DIV>
+<DIV ID="29p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="29px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('29',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Tony Bradley / <A HREF="http://www.pcworld.com/">PC World</A>:</CITE> &nbsp; <A HREF="http://www.pcworld.com/article/211150/">Adobe Reader X Makes PDF Files Safer</A></DIV><DIV CLASS="lnkr"><CITE>Brad Arkin / <A HREF="http://blogs.adobe.com/asset">Adobe Secure Software Engineering Team &hellip;</A>:</CITE> &nbsp; <A HREF="http://blogs.adobe.com/asset/2010/11/adobe-reader-x-is-here.html">Adobe Reader X is Here!&nbsp; &mdash;&nbsp; Since we first announced the development &hellip; </A></DIV><DIV CLASS="lnkr"><CITE>Martin / <A HREF="http://www.ghacks.net/">gHacks Technology News</A>:</CITE> &nbsp; <A HREF="http://www.ghacks.net/2010/11/19/adobe-reader-x-download-available/">Adobe Reader X Download Available</A></DIV><DIV CLASS="lnkr"><CITE>Samuel Gibbs / <A HREF="http://www.downloadsquad.com/">Download Squad</A>:</CITE> &nbsp; <A HREF="http://www.downloadsquad.com/2010/11/19/adobe-reader-x-for-android-and-desktop-available-now/">Adobe Reader X now available for Android and desktop OSes</A></DIV><DIV CLASS="lnkr"><CITE>Amit / <A HREF="http://www.labnol.org/">Digital Inspiration Technology Blog</A>:</CITE> &nbsp; <A HREF="http://www.labnol.org/software/adobe-reader-with-file-sharing/18209/">One-Click File Sharing with Adobe Reader X</A></DIV><DIV CLASS="lnkr"><CITE>Lawrence Latif / <A HREF="http://www.theinquirer.net/">Inquirer</A>:</CITE> &nbsp; <A HREF="http://www.theinquirer.net/inquirer/news/1899227/adobe-ring-fences-pdf-reader?WT.rss_f=News&WT.rss_a=Adobe+ring-fences+its+PDF+Reader">Adobe ring-fences its PDF Reader</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://threatpost.com/en_us/weblog/digital_underground">Dennis Fisher</A>:</CITE> &nbsp; <A HREF="http://threatpost.com/en_us/blogs/adobe-releases-reader-x-sandbox-111810">Adobe Releases Reader X With Sandbox</A></DIV><DIV CLASS="lnkr"><CITE>Iain Thomson / <A HREF="http://www.v3.co.uk/">V3.co.uk</A>:</CITE> &nbsp; <A HREF="http://www.v3.co.uk/v3/news/2273313/adobe-reader-pdf-sandbox">Adobe upgrades to sandboxed Reader X for Windows</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p73"></A>
+<DIV CLASS="heditem" ID="101118p73" ONMOUSEOVER="nnid('30dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p73#a101118p73" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s33');
+--></script>
+<CITE>Greg Sterling / <A HREF="http://searchengineland.com/">Search Engine Land</A>:</CITE>
+<span id="s33" pml="101118p73" spml="AJG9" bitly="ak1zWH" url="http://searchengineland.com/boutiques-com-a-very-different-look-from-google-56283" head="Boutiques.com: A Very Different Shopping Site For Women, From Google (@gsterling / Search Engine Land)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://searchengineland.com/boutiques-com-a-very-different-look-from-google-56283">Boutiques.com: A Very Different Shopping Site For Women, From Google</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://searchengineland.com/boutiques-com-a-very-different-look-from-google-56283');
+--></SCRIPT>
+<DIV ID="30d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('30dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="30dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('30',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.informationweek.com/news/global-cio/trends/showArticle.jhtml?articleID=228300115">InformationWeek</A>, <A HREF="http://www.intomobile.com/2010/11/18/google-boutiques-ipad-app/">IntoMobile</A>, <A HREF="http://www.pcworld.com/article/211098/">PC World</A> and <A HREF="http://www.tnooz.com/2010/11/18/news/google-gets-into-metasearch-after-a-fashion-with-boutiques-com/">Tnooz</A></SPAN>
+</DIV></DIV>
+<DIV ID="30p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="30px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('30',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Antone Gonsalves / <A HREF="http://www.informationweek.com/">InformationWeek</A>:</CITE> &nbsp; <A HREF="http://www.informationweek.com/news/global-cio/trends/showArticle.jhtml?articleID=228300115">Google Unveils &lsquo;Boutiques&rsquo; Fashion Search Site</A></DIV><DIV CLASS="lnkr"><CITE>Marin Perez / <A HREF="http://www.intomobile.com/">IntoMobile</A>:</CITE> &nbsp; <A HREF="http://www.intomobile.com/2010/11/18/google-boutiques-ipad-app/">Google Boutiques iPad app helps you dress like Snooki</A></DIV><DIV CLASS="lnkr"><CITE>Sharon Gaudin / <A HREF="http://www.pcworld.com/">PC World</A>:</CITE> &nbsp; <A HREF="http://www.pcworld.com/article/211098/">Geek Chic: Google Launches Boutiques.com</A></DIV><DIV CLASS="lnkr"><CITE>Dennis Schaal / <A HREF="http://www.tnooz.com/">Tnooz</A>:</CITE> &nbsp; <A HREF="http://www.tnooz.com/2010/11/18/news/google-gets-into-metasearch-after-a-fashion-with-boutiques-com/">Google gets into metasearch after a fashion with Boutiques.com</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p71"></A>
+<DIV CLASS="heditem" ID="101118p71" ONMOUSEOVER="nnid('31dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p71#a101118p71" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s34');
+--></script>
+<CITE>Nate Anderson / <A HREF="http://arstechnica.com/">Ars Technica</A>:</CITE>
+<span id="s34" pml="101118p71" spml="AJG7" bitly="cIDSpo" url="http://arstechnica.com/tech-policy/news/2010/11/swedes-arrest-wikileaks-founder-in-absentia.ars" head="Swedes detain Wikileaks founder in absentia (Nate Anderson / Ars Technica)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://arstechnica.com/tech-policy/news/2010/11/swedes-arrest-wikileaks-founder-in-absentia.ars">Swedes detain Wikileaks founder in absentia</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://arstechnica.com/tech-policy/news/2010/11/swedes-arrest-wikileaks-founder-in-absentia.ars');
+--></SCRIPT>
+<DIV ID="31d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('31dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="31dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('31',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.betanews.com/article/Sweden-wants-Wikileaks-founder-Assange-detained-for-rape-charges/1290101005">BetaNews</A></SPAN>
+</DIV></DIV>
+<DIV ID="31p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="31px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('31',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Ed Oswald / <A HREF="http://www.betanews.com/">BetaNews</A>:</CITE> &nbsp; <A HREF="http://www.betanews.com/article/Sweden-wants-Wikileaks-founder-Assange-detained-for-rape-charges/1290101005">Sweden wants Wikileaks' founder Assange detained for rape charges</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p70"></A>
+<DIV CLASS="heditem" ID="101118p70" ONMOUSEOVER="nnid('32dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p70#a101118p70" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s35');
+--></script>
+<CITE>Robin Wauters / <A HREF="http://techcrunch.com/">TechCrunch</A>:</CITE>
+<span id="s35" pml="101118p70" spml="AJG6" bitly="a7eQTM" url="http://techcrunch.com/2010/11/18/zemanta-funding/" head="Zemanta Raises $3 Million From Union Square, Eden, To Help You "Blog Smarter" (@robinwauters /..." class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://techcrunch.com/2010/11/18/zemanta-funding/">Zemanta Raises $3 Million From Union Square, Eden, To Help You &ldquo;Blog Smarter&rdquo;</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://techcrunch.com/2010/11/18/zemanta-funding/');
+--></SCRIPT>
+<DIV ID="32d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('32dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="32dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('32',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.zemanta.com/blog/zemanta-raises-biggest-financing-round-to-date/">Z-Blog</A>, <A HREF="http://vator.tv/news/2010-11-18-zemanta-makes-a-3m-round-for-blogging-tool">VatorNews</A>, <A HREF="http://venturebeat.com/2010/11/18/blog-plug-in-zemanta-scores-3m-as-it-heads-towards-profitability/">VentureBeat</A>, <A HREF="http://www.businessinsider.com/zemanta-raises-3-million-more-from-union-square-ventures-and-eden-ventures-2010-11">SAI</A> and <A HREF="http://paidcontent.org/article/419-related-links-blog-plugin-zemanta-raises-3-million/">paidContent</A>, <SPAN STYLE="background:#ffc;padding: 0 1px;"><A HREF="http://mediagazer.com/#a101118p24">more at <B>Mediagazer</B> &raquo;</A></SPAN></SPAN>
+</DIV></DIV>
+<DIV ID="32p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="32px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('32',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Bostjan / <A HREF="http://www.zemanta.com/blog">Z-Blog</A>:</CITE> &nbsp; <A HREF="http://www.zemanta.com/blog/zemanta-raises-biggest-financing-round-to-date/">Zemanta Raises Biggest Financing Round To Date</A></DIV><DIV CLASS="lnkr"><CITE>Ronny Kerr / <A HREF="http://vator.tv/news/">VatorNews</A>:</CITE> &nbsp; <A HREF="http://vator.tv/news/2010-11-18-zemanta-makes-a-3m-round-for-blogging-tool">Zemanta makes a $3M round for blogging tool</A></DIV><DIV CLASS="lnkr"><CITE>Riley McDermid / <A HREF="http://venturebeat.com/">VentureBeat</A>:</CITE> &nbsp; <A HREF="http://venturebeat.com/2010/11/18/blog-plug-in-zemanta-scores-3m-as-it-heads-towards-profitability/">Blog plug-in Zemanta scores $3M as it heads towards profitability</A></DIV><DIV CLASS="lnkr"><CITE>Dan Frommer / <A HREF="http://www.businessinsider.com/sai">SAI: Silicon Alley Insider</A>:</CITE> &nbsp; <A HREF="http://www.businessinsider.com/zemanta-raises-3-million-more-from-union-square-ventures-and-eden-ventures-2010-11">Zemanta Raises $3 Million More From Union Square Ventures And Eden Ventures</A></DIV><DIV CLASS="lnkr"><CITE>Robert Andrews / <A HREF="http://www.paidcontent.org/">paidContent</A>:</CITE> &nbsp; <A HREF="http://paidcontent.org/article/419-related-links-blog-plugin-zemanta-raises-3-million/">Related-Links Blog Plugin Zemanta Raises $3 Million</A></DIV><DIV CLASS="lnkr"><SPAN STYLE="background:#ffc;padding: 0 1px;"><A HREF="http://mediagazer.com/#a101118p24">more at <B>Mediagazer</B> &raquo;</A></SPAN></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p69"></A>
+<DIV CLASS="heditem" ID="101118p69" ONMOUSEOVER="nnid('33dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p69#a101118p69" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s36');
+--></script>
+<CITE>Ben Popper / <A HREF="http://www.observer.com/">New York Observer</A>:</CITE>
+<span id="s36" pml="101118p69" spml="AJG5" bitly="aPE18N" url="http://www.observer.com/2010/daily-transom/now-its-personal-apple-taking-teen-who-sold-white-iphones" head="Now It's Personal: Apple Taking on Teen Who Sold White iPhones (@benpopper / New York Observer)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://www.observer.com/2010/daily-transom/now-its-personal-apple-taking-teen-who-sold-white-iphones">Now It's Personal: Apple Taking on Teen Who Sold White iPhones</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.observer.com/2010/daily-transom/now-its-personal-apple-taking-teen-who-sold-white-iphones');
+--></SCRIPT>
+<DIV ID="33d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('33dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="33dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('33',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://techland.com/2010/11/18/teen-may-face-legal-action-for-selling-white-iphone-4g-kits/">Techland</A>, <A HREF="http://www.fastcompany.com/1703553/exclusive-qa-white-iphone-4-seller-on-trademark-infringement-apple-foxconn-private-investiga">Fast Company</A> and <A HREF="http://www.businessinsider.com/apple-going-after-17-year-old-for-selling-white-iphone-conversion-kit-2010-11">SAI</A></SPAN>
+</DIV></DIV>
+<DIV ID="33p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="33px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('33',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Michelle Castillo / <A HREF="http://techland.com/">Techland</A>:</CITE> &nbsp; <A HREF="http://techland.com/2010/11/18/teen-may-face-legal-action-for-selling-white-iphone-4g-kits/">Teen May Face Legal Action For Selling White iPhone 4G Kits</A></DIV><DIV CLASS="lnkr"><CITE>Austin Carr / <A HREF="http://www.fastcompany.com/">Fast Company</A>:</CITE> &nbsp; <A HREF="http://www.fastcompany.com/1703553/exclusive-qa-white-iphone-4-seller-on-trademark-infringement-apple-foxconn-private-investiga">Exclusive Q&amp;A: How the White iPhone 4 Kid Got Rich Buying Genuine &hellip; </A></DIV><DIV CLASS="lnkr"><CITE>Jay Yarow / <A HREF="http://www.businessinsider.com/sai">SAI: Silicon Alley Insider</A>:</CITE> &nbsp; <A HREF="http://www.businessinsider.com/apple-going-after-17-year-old-for-selling-white-iphone-conversion-kit-2010-11">Apple Harassing 17 Year Old For Selling White iPhone Conversion Kit</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="halfcol">
+<DIV CLASS="padlr">
+<DIV CLASS="col0rn">
+<DIV CLASS="rncont">
+<DIV CLASS="rnhdbak">
+<SPAN CLASS="rnhd1">&nbsp;</SPAN><SPAN CLASS="rnhd2">Earlier Items:</SPAN><SPAN CLASS="rnhd3">&nbsp;</SPAN>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="nornbody">
+<A NAME="a101118p65"></A>
+<DIV CLASS="heditem" ID="101118p65" ONMOUSEOVER="nnid('34dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p65#a101118p65" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s37');
+--></script>
+<CITE>Philip Elmer-DeWitt / <A HREF="http://www.fortune.com/">Fortune</A>:</CITE>
+<span id="s37" pml="101118p65" spml="AJG1" bitly="bj8E2t" url="http://tech.fortune.cnn.com/2010/11/18/apples-new-board-member-virginias-computer-nightmare/" head="Apple's new board member, Virginia's computer nightmare (@philiped / Fortune)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://tech.fortune.cnn.com/2010/11/18/apples-new-board-member-virginias-computer-nightmare/">Apple's new board member, Virginia's computer nightmare</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://tech.fortune.cnn.com/2010/11/18/apples-new-board-member-virginias-computer-nightmare/');
+--></SCRIPT>
+<DIV ID="34d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('34dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="34dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('34',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.9to5mac.com/36426/apples-sugar-tech-disaster-and-virginia-state">9 to 5 Mac</A></SPAN>
+</DIV></DIV>
+<DIV ID="34p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="34px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('34',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Jonny Evans / <A HREF="http://www.9to5mac.com/">9 to 5 Mac</A>:</CITE> &nbsp; <A HREF="http://www.9to5mac.com/36426/apples-sugar-tech-disaster-and-virginia-state">Apple's Sugar, tech disaster and Virginia State</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p61"></A>
+<DIV CLASS="heditem" ID="101118p61" ONMOUSEOVER="nnid()">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p61#a101118p61" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s38');
+--></script>
+<CITE>David Kaplan / <A HREF="http://www.paidcontent.org/">paidContent</A>:</CITE>
+<span id="s38" pml="101118p61" spml="AJFx" bitly="dqGJ7Z" url="http://paidcontent.org/article/419-googles-arora-on-the-world-of-tomorrow-facebook-and-google-wont-dominat/" head="Google's Arora On The World Of Tomorrow: Facebook And Google Won't Dominate (@davidakaplan /..." class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://paidcontent.org/article/419-googles-arora-on-the-world-of-tomorrow-facebook-and-google-wont-dominat/">Google's Arora On The World Of Tomorrow: Facebook And Google Won't Dominate</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://paidcontent.org/article/419-googles-arora-on-the-world-of-tomorrow-facebook-and-google-wont-dominat/');
+--></SCRIPT>
+</DIV>
+<A NAME="a101118p60"></A>
+<DIV CLASS="heditem" ID="101118p60" ONMOUSEOVER="nnid('36dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p60#a101118p60" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s39');
+--></script>
+<CITE>Paul T. Rosynsky / <A HREF="http://www.mercurynews.com/">Mercury News</A>:</CITE>
+<span id="s39" pml="101118p60" spml="AJFw" bitly="dyn4yC" url="http://www.mercurynews.com/ci_16640786" head="Overstock.com sued by district attorneys (Paul T. Rosynsky / Mercury News)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://www.mercurynews.com/ci_16640786">Overstock.com sued by district attorneys</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.mercurynews.com/ci_16640786');
+--></SCRIPT>
+<DIV ID="36d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('36dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="36dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('36',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://econsultancy.com/us/blog/6867-overstock-com-when-a-deal-isn-t-a-deal">the Econsultancy blog</A> and <A HREF="http://money.cnn.com/2010/11/18/technology/overstock_discounts_lawsuit/">CNNMoney.com</A></SPAN>
+</DIV></DIV>
+<DIV ID="36p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="36px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('36',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Patricio Robles / <A HREF="http://econsultancy.com/us/blog">the Econsultancy blog</A>:</CITE> &nbsp; <A HREF="http://econsultancy.com/us/blog/6867-overstock-com-when-a-deal-isn-t-a-deal">Overstock.com: when a deal isn't a deal&nbsp; &mdash;&nbsp; Consumers today love &hellip; </A></DIV><DIV CLASS="lnkr"><CITE>Annalyn Censky / <A HREF="http://money.cnn.com/">CNNMoney.com</A>:</CITE> &nbsp; <A HREF="http://money.cnn.com/2010/11/18/technology/overstock_discounts_lawsuit/">Overstock.com sued for overstating discounts</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p57"></A>
+<DIV CLASS="heditem" ID="101118p57" ONMOUSEOVER="nnid('37dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p57#a101118p57" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s40');
+--></script>
+<CITE>Chris Nerney / <A HREF="http://www.itworld.com/">ITworld</A>:</CITE>
+<span id="s40" pml="101118p57" spml="AJFt" bitly="d1Zt8W" url="http://www.itworld.com/business/128113/mark-zuckerbergs-first-website-harvard-sold-online-auction" head="Mark Zuckerberg's first website at Harvard sold in online auction (@chrisnerney / ITworld)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://www.itworld.com/business/128113/mark-zuckerbergs-first-website-harvard-sold-online-auction">Mark Zuckerberg's first website at Harvard sold in online auction</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.itworld.com/business/128113/mark-zuckerbergs-first-website-harvard-sold-online-auction');
+--></SCRIPT>
+<DIV ID="37d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('37dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="37dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('37',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://blogs.forbes.com/clareoconnor/2010/11/18/sold-mystery-buyer-snaps-up-mark-zuckerbergs-first-website/">Filthy Rich</A> and <A HREF="http://www.domainquestions.com/does-facebook-retain-the-rights-to-face-mash/">DomainQuestions.com</A></SPAN>
+</DIV></DIV>
+<DIV ID="37p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="37px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('37',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Clare O'Connor / <A HREF="http://blogs.forbes.com/clareoconnor">Filthy Rich</A>:</CITE> &nbsp; <A HREF="http://blogs.forbes.com/clareoconnor/2010/11/18/sold-mystery-buyer-snaps-up-mark-zuckerbergs-first-website/">Sold! Mystery Buyer Snaps Up Mark Zuckerberg's First Website</A></DIV><DIV CLASS="lnkr"><CITE>Elliot Silver / <A HREF="http://www.domainquestions.com/">DomainQuestions.com</A>:</CITE> &nbsp; <A HREF="http://www.domainquestions.com/does-facebook-retain-the-rights-to-face-mash/">Does Facebook retain the rights to &ldquo;Face Mash&rdquo;?</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p52"></A>
+<DIV CLASS="heditem" ID="101118p52" ONMOUSEOVER="nnid('38dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p52#a101118p52" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s41');
+--></script>
+<CITE>Oliver Chiang / <A HREF="http://blogs.forbes.com/oliverchiang">SelectStart</A>:</CITE>
+<span id="s41" pml="101118p52" spml="AJFo" bitly="aXNjTZ" url="http://blogs.forbes.com/oliverchiang/2010/11/17/meet-the-man-who-paid-a-record-335000-for-virtual-property/" head="Meet The Man Who Paid A Record $335,000 For Virtual Property (@ojchiang / SelectStart)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://blogs.forbes.com/oliverchiang/2010/11/17/meet-the-man-who-paid-a-record-335000-for-virtual-property/">Meet The Man Who Paid A Record $335,000 For Virtual Property</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://blogs.forbes.com/oliverchiang/2010/11/17/meet-the-man-who-paid-a-record-335000-for-virtual-property/');
+--></SCRIPT>
+<DIV ID="38d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('38dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="38dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('38',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.geek.com/articles/games/nightclub-in-sci-fi-mmo-entropia-sells-for-335000-20101119/">Geek.com</A>, <A HREF="http://www.switched.com/2010/11/18/steven-slater-hawks-voip-service-economist-coming-to-ipad-and-i/">Switched</A>, <A HREF="http://www.marketingpilgrim.com/2010/11/consumers-expected-to-spend-7-billion-on-imaginary-goods.html">Andy Beal's Marketing Pilgrim</A>, <A HREF="http://gizmodo.com/5693093/">Gizmodo</A>, <A HREF="http://everwas.com/2010/11/335-for-virtual-property-what-bubble.html">everwas</A>, <A HREF="http://www.vizworld.com/2010/11/man-paid-335000-virtual-real-estate-explains/">VizWorld.com</A>, <A HREF="http://www.gizmodo.com.au/2010/11/man-who-paid-us335000-for-virtual-real-estate-explains-why/">Gizmodo Australia</A>, <A HREF="http://www.publicradio.org/columns/marketplace/tech-report/2010/11/guy-pays-335000-for-virtual-building.html">Tech Report</A> and <A HREF="http://www.fudzilla.com/home/item/20910-in-game-location-sold-for-$335000">Fudzilla</A></SPAN>
+</DIV></DIV>
+<DIV ID="38p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="38px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('38',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>John Brownlee / <A HREF="http://www.geek.com/">Geek.com</A>:</CITE> &nbsp; <A HREF="http://www.geek.com/articles/games/nightclub-in-sci-fi-mmo-entropia-sells-for-335000-20101119/">Nightclub in sci-fi MMO Entropia sells for $335,000</A></DIV><DIV CLASS="lnkr"><CITE>Thomas Houston / <A HREF="http://www.switched.com/">Switched</A>:</CITE> &nbsp; <A HREF="http://www.switched.com/2010/11/18/steven-slater-hawks-voip-service-economist-coming-to-ipad-and-i/">Steven Slater Hawks VoIP Service, Economist Coming to iPad and iPhone</A></DIV><DIV CLASS="lnkr"><CITE>Cynthia Boris / <A HREF="http://www.marketingpilgrim.com/">Andy Beal's Marketing Pilgrim</A>:</CITE> &nbsp; <A HREF="http://www.marketingpilgrim.com/2010/11/consumers-expected-to-spend-7-billion-on-imaginary-goods.html">Consumers Expected to Spend 7 Billion on Imaginary Goods</A></DIV><DIV CLASS="lnkr"><CITE>Kat Hannaford / <A HREF="http://gizmodo.com/">Gizmodo</A>:</CITE> &nbsp; <A HREF="http://gizmodo.com/5693093/">Man Who Paid $335,000 for Virtual Real Estate Explains Why</A></DIV><DIV CLASS="lnkr"><CITE>Ian Kennedy / <A HREF="http://everwas.com/">everwas</A>:</CITE> &nbsp; <A HREF="http://everwas.com/2010/11/335-for-virtual-property-what-bubble.html">$335k For Virtual Property, What Bubble?</A></DIV><DIV CLASS="lnkr"><CITE>Randall Hand / <A HREF="http://www.vizworld.com/">VizWorld.com</A>:</CITE> &nbsp; <A HREF="http://www.vizworld.com/2010/11/man-paid-335000-virtual-real-estate-explains/">Man Who Paid $335,000 for Virtual Real Estate Explains Why</A></DIV><DIV CLASS="lnkr"><CITE>Kat Hannaford / <A HREF="http://www.gizmodo.com.au/">Gizmodo Australia</A>:</CITE> &nbsp; <A HREF="http://www.gizmodo.com.au/2010/11/man-who-paid-us335000-for-virtual-real-estate-explains-why/">Man Who Paid $US335,000 For Virtual Real Estate Explains Why</A></DIV><DIV CLASS="lnkr"><CITE>John Moe / <A HREF="http://www.publicradio.org/columns/marketplace/tech-report/">Tech Report</A>:</CITE> &nbsp; <A HREF="http://www.publicradio.org/columns/marketplace/tech-report/2010/11/guy-pays-335000-for-virtual-building.html">Guy pays $335,000 for virtual building</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://www.fudzilla.com/">Fudzilla</A>:</CITE> &nbsp; <A HREF="http://www.fudzilla.com/home/item/20910-in-game-location-sold-for-$335000">In-game location sold for $335,000</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p51"></A>
+<DIV CLASS="heditem" ID="101118p51" ONMOUSEOVER="nnid('39dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p51#a101118p51" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s42');
+--></script>
+<CITE>Stacey Higginbotham / <A HREF="http://gigaom.com/">GigaOM</A>:</CITE>
+<span id="s42" pml="101118p51" spml="AJFn" bitly="aOCykT" url="http://gigaom.com/2010/11/18/carrier-organization-changes-rules-to-allow-the-apple-sim/" head="Carrier Organization Changes Rules to Allow the "Apple SIM" (@gigastacey / GigaOM)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://gigaom.com/2010/11/18/carrier-organization-changes-rules-to-allow-the-apple-sim/">Carrier Organization Changes Rules to Allow the &ldquo;Apple SIM&rdquo;</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://gigaom.com/2010/11/18/carrier-organization-changes-rules-to-allow-the-apple-sim/');
+--></SCRIPT>
+<DIV ID="39d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('39dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="39dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('39',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.appleinsider.com/articles/10/11/18/european_carriers_threaten_apple_over_embedded_sim_option.html">AppleInsider</A>, <A HREF="http://www.gsmworld.com/newsroom/press-releases/2010/5726.htm">GSM World</A>, <A HREF="http://moconews.net/article/419-apple-tests-operators-patience-with-soft-sim-plans/">mocoNews</A>, <A HREF="http://thenextweb.com/mobile/2010/11/19/european-carriers-close-ranks-against-apples-embedded-sim-plan/">The Next Web</A>, <A HREF="http://www.iphoneworld.ca/news/2010/11/18/gsma-approves-embedded-programmable-sim-cards-apple-will-make-iphone-unlocking-impossible/">iPhoneWorld.ca iPhone</A>, <A HREF="http://www.9to5mac.com/36532/european-iphone-subsidies-may-end-over-integrated-sim-technology">9 to 5 Mac</A>, <A HREF="http://connectedplanetonline.com/bss_oss/news/The-time-has-come-for-more-connected-devices-1118">Connected Planet Online</A>, <A HREF="http://www.intomobile.com/2010/11/17/gsma-embedded-sim/">IntoMobile</A> and <A HREF="http://news.softpedia.com/news/GSMA-Plans-Embedded-SIM-Cards-with-Remote-Activation-167156.shtml">Softpedia News</A></SPAN>
+</DIV></DIV>
+<DIV ID="39p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="39px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('39',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Josh Ong / <A HREF="http://appleinsider.com/">AppleInsider</A>:</CITE> &nbsp; <A HREF="http://www.appleinsider.com/articles/10/11/18/european_carriers_threaten_apple_over_embedded_sim_option.html">European carriers threaten Apple over embedded SIM option</A></DIV><DIV CLASS="lnkr"><CITE>Howard Jones / <A HREF="http://www.gsmworld.com/">GSM World</A>:</CITE> &nbsp; <A HREF="http://www.gsmworld.com/newsroom/press-releases/2010/5726.htm">GSMA Launches Embedded SIM Initiative to Support the Connected Future</A></DIV><DIV CLASS="lnkr"><CITE>Ingrid Lunden / <A HREF="http://moconews.net/">mocoNews</A>:</CITE> &nbsp; <A HREF="http://moconews.net/article/419-apple-tests-operators-patience-with-soft-sim-plans/">Apple Tests Operators' Patience With &lsquo;Soft Sim&rsquo; Plans</A></DIV><DIV CLASS="lnkr"><CITE>Fraser Smith / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/mobile/2010/11/19/european-carriers-close-ranks-against-apples-embedded-sim-plan/">European carriers close ranks against Apple's embedded SIM plan</A></DIV><DIV CLASS="lnkr"><CITE>James / <A HREF="http://www.iphoneworld.ca/">iPhoneWorld.ca iPhone</A>:</CITE> &nbsp; <A HREF="http://www.iphoneworld.ca/news/2010/11/18/gsma-approves-embedded-programmable-sim-cards-apple-will-make-iphone-unlocking-impossible/">GSMA approves embedded programmable SIM cards: Apple to make &hellip; </A></DIV><DIV CLASS="lnkr"><CITE>Mark Gurman / <A HREF="http://www.9to5mac.com/">9 to 5 Mac</A>:</CITE> &nbsp; <A HREF="http://www.9to5mac.com/36532/european-iphone-subsidies-may-end-over-integrated-sim-technology">European iPhone subsidies may end over integrated SIM technology</A></DIV><DIV CLASS="lnkr"><CITE>Susana Schwartz / <A HREF="http://connectedplanetonline.com/">Connected Planet Online</A>:</CITE> &nbsp; <A HREF="http://connectedplanetonline.com/bss_oss/news/The-time-has-come-for-more-connected-devices-1118">GSMA: The time has come for more connected devices</A></DIV><DIV CLASS="lnkr"><CITE>Stefan Constantinescu / <A HREF="http://www.intomobile.com/">IntoMobile</A>:</CITE> &nbsp; <A HREF="http://www.intomobile.com/2010/11/17/gsma-embedded-sim/">GSMA looking at making future SIM cards embedded into devices &hellip; </A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://news.softpedia.com/">Softpedia News</A>:</CITE> &nbsp; <A HREF="http://news.softpedia.com/news/GSMA-Plans-Embedded-SIM-Cards-with-Remote-Activation-167156.shtml">GSMA Plans Embedded SIM Cards with Remote Activation</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p47"></A>
+<DIV CLASS="heditem" ID="101118p47" ONMOUSEOVER="nnid('40dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p47#a101118p47" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s43');
+--></script>
+<CITE>Federico Viticci / <A HREF="http://www.macstories.net/">MacStories</A>:</CITE>
+<span id="s43" pml="101118p47" spml="AJFj" bitly="9Thn7l" url="http://www.macstories.net/news/apple-releases-ios-4-2-1-gm-build/" head="Apple Releases iOS 4.2.1 GM Build (@viticci / MacStories)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://www.macstories.net/news/apple-releases-ios-4-2-1-gm-build/">Apple Releases iOS 4.2.1 GM Build</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://www.macstories.net/news/apple-releases-ios-4-2-1-gm-build/');
+--></SCRIPT>
+<DIV ID="40d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('40dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="40dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('40',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.macrumors.com/2010/11/18/apple-releases-ios-4-2-1-golden-master-to-developers/">MacRumors</A>, <A HREF="http://www.engadget.com/2010/11/18/apple-posts-ios-4-2-1-gm-seed-ipads-salivate-in-wait/">Engadget</A>, <A HREF="http://www.coveringweb.com/2010/11/jailbreak-ios-421-gm-on-iphone-4-3gs-3g.html">Covering Web</A>, <A HREF="http://www.examiner.com/technology-in-national/ios-4-2-1-gold-master-seeded-though-ios-4-2-hasn-t-been-released-yet">Examiner</A>, <A HREF="http://news.idg.no/cw/art.cfm?id=60EB6828-1A64-6A71-CE445255C869CD96">Computerworld</A>, <A HREF="http://www.9to5mac.com/36462/ios-4-2-1-gm-released-to-developers">9 to 5 Mac</A>, <A HREF="http://www.i4u.com/42720/while-we-are-waiting-ios-42-release-developers-already-got-ios-421">I4U News</A>, <A HREF="http://www.intomobile.com/2010/11/18/apple-cuts-ios-4-2-1-gm-build-loose/">IntoMobile</A>, <A HREF="http://appadvice.com/appnn/2010/11/breaking-apple-releases-ios-421-gm-developers/">App Advice</A>, <A HREF="http://www.bgr.com/2010/11/18/67228/">BGR</A>, <A HREF="http://www.tipb.com/2010/11/18/apple-software-update-servers-ios-42-imminent/">TiPb</A>, <A HREF="http://www.businessinsider.com/new-version-of-ios-was-just-released-to-developers-2010-11">SAI</A>, <A HREF="http://www.tuaw.com/2010/11/18/ios-4-2-1-gold-master-posted-to-dev-center/">TUAW</A> and <A HREF="http://www.downloadsquad.com/2010/11/18/apple-releases-ios-4-2-1-gm-still-no-public-release-of-ios-4-2/">Download Squad</A>, <SPAN CLASS="drhed">Thanks:</SPAN><A HREF="http://twitter.com/viticci/statuses/5349689427759104">viticci</A></SPAN>
+</DIV></DIV>
+<DIV ID="40p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="40px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('40',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Eric Slivka / <A HREF="http://www.macrumors.com/">MacRumors</A>:</CITE> &nbsp; <A HREF="http://www.macrumors.com/2010/11/18/apple-releases-ios-4-2-1-golden-master-to-developers/">Apple Releases iOS 4.2.1 Golden Master to Developers</A></DIV><DIV CLASS="lnkr"><CITE>Chris Ziegler / <A HREF="http://www.engadget.com/">Engadget</A>:</CITE> &nbsp; <A HREF="http://www.engadget.com/2010/11/18/apple-posts-ios-4-2-1-gm-seed-ipads-salivate-in-wait/">Apple posts iOS 4.2.1 GM seed, iPads salivate in wait</A></DIV><DIV CLASS="lnkr"><CITE>Gamal Sabry / <A HREF="http://www.coveringweb.com/">Covering Web</A>:</CITE> &nbsp; <A HREF="http://www.coveringweb.com/2010/11/jailbreak-ios-421-gm-on-iphone-4-3gs-3g.html">Jailbreak iOS 4.2.1 GM on iPhone 4, 3GS, 3G and iPod touch 4G &hellip; </A></DIV><DIV CLASS="lnkr"><CITE>Michael Santo / <A HREF="http://www.examiner.com/">Examiner</A>:</CITE> &nbsp; <A HREF="http://www.examiner.com/technology-in-national/ios-4-2-1-gold-master-seeded-though-ios-4-2-hasn-t-been-released-yet">iOS 4.2.1 gold master seeded, though iOS 4.2 hasn't been released yet</A></DIV><DIV CLASS="lnkr"><CITE><A HREF="http://computerworld.com/">Computerworld</A>:</CITE> &nbsp; <A HREF="http://news.idg.no/cw/art.cfm?id=60EB6828-1A64-6A71-CE445255C869CD96">Apple releases iOS 4.2.1 GM to developers</A></DIV><DIV CLASS="lnkr"><CITE>Seth Weintraub / <A HREF="http://www.9to5mac.com/">9 to 5 Mac</A>:</CITE> &nbsp; <A HREF="http://www.9to5mac.com/36462/ios-4-2-1-gm-released-to-developers">iOS 4.2.1 GM released to developers</A></DIV><DIV CLASS="lnkr"><CITE>Luigi Lugmayr / <A HREF="http://www.i4u.com/">I4U News</A>:</CITE> &nbsp; <A HREF="http://www.i4u.com/42720/while-we-are-waiting-ios-42-release-developers-already-got-ios-421">While we are waiting for the iOS 4.2 Release, Developers already got iOS 4.2.1</A></DIV><DIV CLASS="lnkr"><CITE>Marc Flores / <A HREF="http://www.intomobile.com/">IntoMobile</A>:</CITE> &nbsp; <A HREF="http://www.intomobile.com/2010/11/18/apple-cuts-ios-4-2-1-gm-build-loose/">Apple cuts iOS 4.2.1 GM build loose</A></DIV><DIV CLASS="lnkr"><CITE>Alexander Vaughn / <A HREF="http://appadvice.com/appnn">App Advice</A>:</CITE> &nbsp; <A HREF="http://appadvice.com/appnn/2010/11/breaking-apple-releases-ios-421-gm-developers/">Breaking: Apple Releases iOS 4.2.1 GM To Developers</A></DIV><DIV CLASS="lnkr"><CITE>Andrew Munchbach / <A HREF="http://www.bgr.com/">BGR</A>:</CITE> &nbsp; <A HREF="http://www.bgr.com/2010/11/18/67228/">Apple seeds iOS 4.2.1 Gold Master candidate to developers</A></DIV><DIV CLASS="lnkr"><CITE>Allyson Kazmucha / <A HREF="http://www.tipb.com/">TiPb</A>:</CITE> &nbsp; <A HREF="http://www.tipb.com/2010/11/18/apple-software-update-servers-ios-42-imminent/">Apple iPhone, iPad Software Update servers down - Start your iOS 4.2 rumors?</A></DIV><DIV CLASS="lnkr"><CITE>Nick Saint / <A HREF="http://www.businessinsider.com/sai">SAI: Silicon Alley Insider</A>:</CITE> &nbsp; <A HREF="http://www.businessinsider.com/new-version-of-ios-was-just-released-to-developers-2010-11">New Version Of iOS Was Just Released To Developers</A></DIV><DIV CLASS="lnkr"><CITE>Victor Agreda, Jr / <A HREF="http://www.tuaw.com/">TUAW</A>:</CITE> &nbsp; <A HREF="http://www.tuaw.com/2010/11/18/ios-4-2-1-gold-master-posted-to-dev-center/">iOS 4.2.1 gold master posted to Apple developer center</A></DIV><DIV CLASS="lnkr"><CITE>Jay Hathaway / <A HREF="http://www.downloadsquad.com/">Download Squad</A>:</CITE> &nbsp; <A HREF="http://www.downloadsquad.com/2010/11/18/apple-releases-ios-4-2-1-gm-still-no-public-release-of-ios-4-2/">Apple releases iOS 4.2.1 GM, still no public release of iOS 4.2</A></DIV><DIV CLASS="lnkr"><SPAN CLASS="drhed">Thanks:</SPAN><A HREF="http://twitter.com/viticci/statuses/5349689427759104">viticci</A></DIV></DIV>
+</DIV>
+</DIV>
+<A NAME="a101118p45"></A>
+<DIV CLASS="heditem" ID="101118p45" ONMOUSEOVER="nnid('41dx1')">
+<NOSCRIPT>
+<A HREF="http://www.techmeme.com/101118/p45#a101118p45" TITLE="Permalink"><IMG SRC="/img/pml.png"></A>
+</NOSCRIPT>
+<script language="javascript"><!--
+writeShareButton('s44');
+--></script>
+<CITE>Hector Ouilhet / <A HREF="http://googlemobile.blogspot.com/">Google Mobile Blog</A>:</CITE>
+<span id="s44" pml="101118p45" spml="AJFh" bitly="bQy7Mv" url="http://googlemobile.blogspot.com/2010/11/google-sky-map-now-with-time-travel.html" head="Google Sky Map- now with time travel (Hector Ouilhet / Google Mobile Blog)" class="sharebox" style="display:none;"></span>
+<BR>
+<STRONG><A HREF="http://googlemobile.blogspot.com/2010/11/google-sky-map-now-with-time-travel.html">Google Sky Map- now with time travel</A></STRONG>
+<SCRIPT LANGUAGE="JavaScript"><!--
+cts('http://googlemobile.blogspot.com/2010/11/google-sky-map-now-with-time-travel.html');
+--></SCRIPT>
+<DIV ID="41d1"><DIV CLASS="mlk" ONMOUSEOVER="dlbid('41dx1')" ONMOUSEOUT="cnxbe()">
+<DIV ID="41dx1" CLASS="show" STYLE="display:none;"><A CLASS="oc" HREF="javascript:tgd('41',true,1)">+</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<SPAN CLASS="mls"><A HREF="http://www.informationweek.com/news/software/web_services/showArticle.jhtml?articleID=228300200">InformationWeek</A>, <A HREF="http://www.businessinsider.com/my-favorite-android-app-sky-map-just-got-time-travel-2010-11">SAI</A>, <A HREF="http://www.intomobile.com/2010/11/18/google-sky-maps-android/">IntoMobile</A>, <A HREF="http://www.mediabistro.com/thinkmobile/google-sky-map-time-travel-option_b8732?c=rss">ThinkMobile</A>, <A HREF="http://thenextweb.com/google/2010/11/18/google-sky-map-now-lets-you-see-star-configurations-in-the-past-and-future/">The Next Web</A>, <A HREF="http://latimesblogs.latimes.com/technology/2010/11/google-sky-map-now-has-time-travel-function.html">L.A. Times Tech Blog</A>, <A HREF="http://www.androidguys.com/2010/11/18/google-time-travel/">AndroidGuys</A> and <A HREF="http://erictric.com/2010/11/18/google-updates-google-sky-map-for-android-to-version-1-6/">Erictric</A></SPAN>
+</DIV></DIV>
+<DIV ID="41p1" STYLE="display: none;"><DIV CLASS="mlk">
+<DIV ID="41px1" CLASS="show"><A CLASS="oc" HREF="javascript:tgd('41',false,1)">&ndash;</A></DIV>
+<SPAN CLASS="drhed">Discussion:</SPAN>
+<DIV CLASS="lnkr"><CITE>Thomas Claburn / <A HREF="http://www.informationweek.com/">InformationWeek</A>:</CITE> &nbsp; <A HREF="http://www.informationweek.com/news/software/web_services/showArticle.jhtml?articleID=228300200">Google Sky Map Enables &lsquo;Time Travel&rsquo;</A></DIV><DIV CLASS="lnkr"><CITE>Matt Rosoff / <A HREF="http://www.businessinsider.com/sai">SAI: Silicon Alley Insider</A>:</CITE> &nbsp; <A HREF="http://www.businessinsider.com/my-favorite-android-app-sky-map-just-got-time-travel-2010-11">My Favorite Android App, Sky Map, Just Got Time Travel</A></DIV><DIV CLASS="lnkr"><CITE>Marin Perez / <A HREF="http://www.intomobile.com/">IntoMobile</A>:</CITE> &nbsp; <A HREF="http://www.intomobile.com/2010/11/18/google-sky-maps-android/">Google Sky Maps for Android gets time travel</A></DIV><DIV CLASS="lnkr"><CITE>Todd Ogasawara / <A HREF="http://www.mediabistro.com/thinkmobile?c=rss">ThinkMobile</A>:</CITE> &nbsp; <A HREF="http://www.mediabistro.com/thinkmobile/google-sky-map-time-travel-option_b8732?c=rss">Google Sky Map Time Travel Option</A></DIV><DIV CLASS="lnkr"><CITE>Chad Catacchio / <A HREF="http://thenextweb.com/">The Next Web</A>:</CITE> &nbsp; <A HREF="http://thenextweb.com/google/2010/11/18/google-sky-map-now-lets-you-see-star-configurations-in-the-past-and-future/">Google Sky Map now lets you see star configurations in the past and future</A></DIV><DIV CLASS="lnkr"><CITE>Tiffany Hsu / <A HREF="http://latimesblogs.latimes.com/technology/">L.A. Times Tech Blog</A>:</CITE> &nbsp; <A HREF="http://latimesblogs.latimes.com/technology/2010/11/google-sky-map-now-has-time-travel-function.html">Google Sky Map now has time travel function</A></DIV><DIV CLASS="lnkr"><CITE>Ray Walters / <A HREF="http://www.androidguys.com/">AndroidGuys</A>:</CITE> &nbsp; <A HREF="http://www.androidguys.com/2010/11/18/google-time-travel/">Google Makes Time Travel Possible</A></DIV><DIV CLASS="lnkr"><CITE>Bertrand Vasquez / <A HREF="http://erictric.com/">Erictric</A>:</CITE> &nbsp; <A HREF="http://erictric.com/2010/11/18/google-updates-google-sky-map-for-android-to-version-1-6/">Google Updates Google Sky Map for Android to Version 1.6</A></DIV></DIV>
+</DIV>
+</DIV>
+</DIV>
+</DIV>
+</DIV>
+<DIV CLASS="clearfloats">&nbsp;</DIV>
+<BR> 
+<STYLE TYPE="text/css" MEDIA="all"> 
+div.xpromo {border-top-style:solid;border-color:#1F4C63;background:#d7e7ee;border-width:0.25em;padding-bottom:0.5em;}
+.xpromo table {font-size:1.25em;}
+.xpromo td {vertical-align:top;text-align:left}
+.xpromo img {float:left;border:1px solid #999;width:37px;height:37px;margin:0 0.5em 0.5em 0;}
+.clnv {clear:both;}
+.clnv A:visited {color:#118;}
+.clnv A:hover {background-color:#118;color:#fff;}
+.spctd {width:2.5em}
+</STYLE> 
+<DIV CLASS="xpromo"> 
+<TABLE WIDTH=100% CELLPADDING=0 CELLSPACING=0> 
+<TR> 
+<TD CLASS="spctd"><DIV CLASS="col0rn"><DIV CLASS="rnhd2">&nbsp;</DIV></DIV></TD> 
+<TD WIDTH=46%> 
+<DIV CLASS="col0rn"><DIV CLASS="rnhdbak"><DIV CLASS="rnhd2">From Mediagazer:</DIV></DIV></DIV>
+<BR>
+<CITE>Alan Rusbridger / Guardian:</CITE><BR> 
+<A HREF="http://mediagazer.com/#a101119p13">The splintering of the fourth estate</A><BR><BR> 
+<CITE>John Koblin / WWD.COM:</CITE><BR> 
+<A HREF="http://mediagazer.com/#a101119p4">Rupert Murdoch Does Another Daily</A><BR><BR> 
+<CITE>Charles Arthur / Guardian:</CITE><BR> 
+<A HREF="http://mediagazer.com/#a101119p16">Journalists of the future need data skills, says Berners-Lee</A><BR><BR> 
+</TD> 
+<TD WIDTH=3.5%><DIV CLASS="col0rn"><DIV CLASS="rnhd2">&nbsp;</DIV></DIV></TD> 
+<TD> 
+<DIV CLASS="col0rn"><DIV CLASS="rnhdbak"><DIV CLASS="rnhd2">Sister Sites:</DIV></DIV></DIV> 
+<BR> 
+<DIV CLASS="clnv"><A HREF="http://mediagazer.com/"><IMG SRC="http://mediagazer.com/m/config/media/iicon.gif"></A> 
+<B><A HREF="http://mediagazer.com/">Mediagazer</A></B><BR>&nbsp;Must-read media news</DIV> 
+<DIV CLASS="clnv"><A HREF="http://www.memeorandum.com/"><IMG SRC="http://www.memeorandum.com/m/config/politics/iicon.gif"></A> 
+<B><A HREF="http://www.memeorandum.com/">memeorandum</A></B><BR>&nbsp;Politics, opinion, and current events</DIV> 
+<DIV CLASS="clnv"><A HREF="http://www.wesmirch.com/"><IMG SRC="http://www.wesmirch.com/m/config/gossip/iicon.gif"></A> 
+<B><A HREF="http://www.wesmirch.com/">WeSmirch</A></B><BR>&nbsp;Celebrity news and gossip</DIV> 
+</TD> 
+<TD CLASS="spctd"><DIV CLASS="col0rn"><DIV CLASS="rnhd2">&nbsp;</DIV></DIV></TD> 
+</TR> 
+</TABLE> 
+</DIV>
+</DIV>
+</DIV>
+&nbsp;
+<script type="text/javascript">
+var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+</script>
+<script type="text/javascript">
+try {
+var pageTracker = _gat._getTracker("UA-433897-4");
+pageTracker._trackPageview();
+} catch(err) {}
+</script>
+</BODY>
+</HTML>
+

--- a/spec/truffle-hog_spec.rb
+++ b/spec/truffle-hog_spec.rb
@@ -38,6 +38,24 @@ describe "parsing html" do
   
   it "returns atom feeds if rss is favored, but none are found"
   it "returns rss feeds if atom is favored, but none are found"
+
+  it "doesn't care about the case of the tag name or attribute" do
+    input = File.read(File.dirname(__FILE__) + "/different_case.html") 
+    feed_urls = TruffleHog.parse_feed_urls(input)
+    feed_urls.should include("http://www.techmeme.com/index.xml")
+  end
+
+  it "doesn't care about the case of the scheme when parsing absolute feed urls" do
+    input = File.read(File.dirname(__FILE__) + "/different_case.html")
+    feed_urls = TruffleHog.parse_feed_urls(input)
+    feed_urls.should include("HTTP://www.techmeme.com/atom.xml")
+  end
+
+  it "matches the href attribute across whitespace" do
+    input = File.read(File.dirname(__FILE__) + "/with_whitespace.html")
+    feed_urls = TruffleHog.parse_feed_urls(input)
+    feed_urls.should include("http://www.pauldix.net/in_head/atom.xml") 
+  end
   
   describe "regressions" do
     it "doesn't go into an infinite loop on this input" do

--- a/spec/with_whitespace.html
+++ b/spec/with_whitespace.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+	"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" id="sixapart-standard">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<meta name="generator" content="http://www.typepad.com/" />
+	
+	<meta name="description" content="Entrepreneurship, programming, software development, politics, NYC, and random thoughts." />
+	<link rel="stylesheet" href="http://www.pauldix.net/styles.css?v=2" type="text/css" media="screen" />
+	<link rel="stylesheet" href="/.shared/themes/common/print.css" type="text/css" media="print" />
+	<link 
+          rel="alternate"
+          type="application/atom+xml"
+          title="Posts on 'Paul Dix Explains Nothing' (Atom)"
+          href="http://www.pauldix.net/in_head/atom.xml" />
+	<link rel="alternate" type="application/rss+xml" title="Posts on 'Paul Dix Explains Nothing' (RSS 1.0)" href="http://www.pauldix.net/in_head/index.rdf" />
+
+	<link rel="alternate" type="application/rss+xml" title="Posts on 'Paul Dix Explains Nothing' (RSS 2.0)" href="http://www.pauldix.net/in_head/rss.xml" />
+
+	<title>Paul Dix Explains Nothing</title>
+	<link rel="openid.server" href="http://www.typepad.com/services/openid/server" />
+	<link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://www.typepad.com/services/rsd/6a00d8341f4a0d53ef00d8341f536453ef" />
+			<link rel="meta" type="application/rdf+xml" title="FOAF" href="http://pauldix.blogs.com/foaf.rdf" />
+	
+        
+</head>
+
+<body class="layout-two-column-right">
+	
+	<div id="container">
+
+		<div id="container-inner" class="pkg">
+			
+			<!-- banner -->
+<div id="banner">
+	<div id="banner-inner" class="pkg">
+		
+		<h1 id="banner-header"><a href="http://www.pauldix.net/" accesskey="1">Paul Dix Explains Nothing</a></h1>
+		<h2 id="banner-description">Entrepreneurship, programming, software development, politics, NYC, and random thoughts.</h2>
+	</div>
+</div>
+
+
+			<div id="pagebody">
+				<div id="pagebody-inner" class="pkg">
+					<div id="alpha">
+						<div id="alpha-inner" class="pkg">
+							<!-- entry list sticky -->
+
+			<h2 class="date-header">October 08, 2009</h2>
+	
+	<div class="entry-author-paul_dix entry-type-post entry" id="entry-6a00d8341f4a0d53ef0120a6247d0c970c">
+
+					<h3 class="entry-header"><a href="http://www.pauldix.net/2009/10/using-the-nginx-memcached-module-with-passenger.html">Using the Nginx Memcached module with Passenger</a></h3>
+		
+		<div class="entry-content">
+			<div class="entry-body">
+				<p>Nginx, everyone&#39;s favorite speedy web server has a module to hook in directly to memcached. For those of us running Ruby servers behind nginx we can avoid hitting our running Ruby processes completely on a cache hit. I&#39;ll avoid the details and point you instead to <a href="http://www.igvita.com/2008/02/11/nginx-and-memcached-a-400-boost/">Ilya Grigorik&#39;s coverage of the Nginx + Memcached</a> goodness.</p>
+
+<p>My trouble was that I couldn&#39;t find a good example of using Passenger and the Nginx memcached module together. The <a href="http://wiki.nginx.org/NginxHttpMemcachedModule">module documentation</a> shows how to proxy cache misses to your running web servers (like Mongrel), but with Passenger you don&#39;t know what processes are running. This is because Passenger automatically spawns web server processes for you. Well, after a little trial and error I figured out a config that works.</p>
+
+<p>I&#39;ll show the config at the bottom of this post, but first let&#39;s look at some performance numbers. For my use case this goes beyond simple page caching. I&#39;m using HTTP services to serve up data. So it&#39;s entirely possible that I can achieve a high cache hit ratio and make things really speedy. To check performance I set up two tests. The first returns a small json object and the second returns a collection of objects. The test Passenger application is a simple Sinatra service that looks like this:</p>
+
+<pre>require &#39;rubygems&#39;<br />require &#39;json&#39;<br />require &#39;sinatra&#39;<br /><br />get &#39;/api/v1/comments/users/:id/no_cache&#39; do<br /> ([{:id =&gt; 2, <br />   :user_id =&gt; &quot;paul&quot;, <br />   :body =&gt; &quot;this is a test comment to see how this thing works.&quot;}<br />  ] * 25).to_json<br />end<br /><br />get &#39;/api/v1/comments/:id/no_cache&#39; do<br /> {:id =&gt; 2, <br />  :user_id =&gt; &quot;paul&quot;, <br />  :body =&gt; &quot;this is a test comment to see how this thing works.&quot;}.to_json<br />end</pre>
+
+<p>The setup was a single small EC2 instance running nginx and another small instance in the same availability zone running Apache Bench against the server. The first run is for cache misses that fall through to Passenger. The second run is against cache hits that go from nginx straight to memcached. Here&#39;s a small section of the results:</p>
+
+<pre># single json object cache miss (passenger)<br />ab -n 10000 -c 50 http://ec2-some-ip.compute-1.amazonaws.com/api/v1/comments/1/no_cache<br />Requests per second: 310.08 [#/sec] (mean)<br />Time per request: 161.249 [ms] (mean)<br />Time per request: 3.225 [ms] (mean, across all concurrent requests)<br />Transfer rate: 94.17 [Kbytes/sec] received<br /><br /># single json object cache hit (nginx + memcached)<br />ab -n 10000 -c 50 http://ec2-some-ip.compute-1.amazonaws.com/api/v1/comments/1<br />Requests per second: 2496.64 [#/sec] (mean)<br />Time per request: 20.027 [ms] (mean)<br />Time per request: 0.401 [ms] (mean, across all concurrent requests)<br />Transfer rate: 556.12 [Kbytes/sec] received<br /><br /># collection of 25 json objects cache miss (passenger)<br />ab -n 10000 -c 50 http://ec2-some-ip.compute-1.amazonaws.com/api/v1/comments/users/1/no_cache<br />Requests per second: 225.98 [#/sec] (mean)<br />Time per request: 221.256 [ms] (mean)<br />Time per request: 4.425 [ms] (mean, across all concurrent requests)<br />Transfer rate: 530.31 [Kbytes/sec] received<br /><br /># collection of 25 json objects cache hit (nginx + memcached)<br />Requests per second: 2385.22 [#/sec] (mean)<br />Time per request: 20.962 [ms] (mean)<br />Time per request: 0.419 [ms] (mean, across all concurrent requests)<br />Transfer rate: 5434.29 [Kbytes/sec] received<br /></pre>
+
+<p>As you can see the time per request and the number of concurrent requests is significantly higher for the cache hits. The performance bump this reflects is actually better than the 400% Ilya mentioned in his blog post (of course, your mileage may vary). If you&#39;re interested, I&#39;ve posted the <a href="http://gist.github.com/205103">full ab output in this gist</a>.</p>
+
+<p>And finally, without any more delay, here&#39;s the nginx.conf I used.</p>
+<pre>user nobody nogroup;<br />worker_processes 4;<br /><br />error_log logs/error.log;<br /><br />events {<br /> worker_connections 1024;<br />}<br /><br />http {<br /> passenger_root /usr/lib/ruby/gems/1.8/gems/passenger-2.2.5;<br /> passenger_ruby /usr/bin/ruby1.8;<br /><br /> include mime.types;<br /> default_type application/octet-stream;<br /> tcp_nopush on;<br /> tcp_nodelay on;<br /> gzip on;<br /><br /> sendfile on;<br /><br /> keepalive_timeout 65;<br /><br /> server {<br /> listen 80;<br /> server_name localhost; # put in your IP in place of localhost<br /> location / {<br /> set $memcached_key $uri;<br /> memcached_pass 127.0.0.1:11211;<br /> default_type application/json;<br /> error_page 404 502 = @fallback;<br /> }<br /><br /> location @fallback {<br /> root /var/www/public;<br /> passenger_enabled on;<br /> }<br /> }<br />}<br /></pre>
+
+			</div>
+			
+							<script src="http://feeds.feedburner.com/~s/PaulDixExplainsNothing?i=http%3A%2F%2Fwww.pauldix.net%2F2009%2F10%2Fusing-the-nginx-memcached-module-with-passenger.html" type="text/javascript"></script>
+			
+		</div>
+		<div class="entry-footer">
+			<p class="entry-footer-info">
+				<span class="post-footers">October 08, 2009 at 11:28 AM </span> <span class="separator">|</span> <a class="permalink" href="http://www.pauldix.net/2009/10/using-the-nginx-memcached-module-with-passenger.html">Permalink</a>
+
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/10/using-the-nginx-memcached-module-with-passenger.html#comments">Comments (0)</a>
+				
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/10/using-the-nginx-memcached-module-with-passenger.html#trackback">TrackBack (0)</a>
+				
+			</p>
+			<!-- technorati tags -->
+	
+
+
+			<!-- post footer links -->
+
+		</div>
+	</div>
+	
+			<h2 class="date-header">September 10, 2009</h2>
+	
+	<div class="entry-author-paul_dix entry-type-post entry" id="entry-6a00d8341f4a0d53ef0120a560db6e970b">
+					<h3 class="entry-header"><a href="http://www.pauldix.net/2009/09/first-nyc-machine-learning-meetup.html">First NYC Machine Learning Meetup</a></h3>
+		
+		<div class="entry-content">
+			<div class="entry-body">
+
+				<p>I have organized the first NYC Machine Learning meetup. The goal of the group is to have discussions based on recent papers in the machine learning community. This can include topics like search, information retrieval, pattern recognition, natural language processing, artificial intelligence, collaborative filtering, recommendation systems, and other topics related to machine learning.</p><p>The format is pretty simple. Pick a research paper. Everyone in the group reads and attempts to understand the paper before the meetup. Meet and discuss with one person leading the discussion. For the first meeting we&#39;ll be going over Yehuda Koren&#39;s paper &quot;<a href="http://research.yahoo.com/files/kdd-fp074-koren.pdf">Collaborative Filtering with Temporal Dynamics</a>.&quot; This paper is based on his work in the BellKor Pragmatic Chaos team that is in contention for the Netflix prize.</p><p>To RSVP go to the <a href="http://www.meetup.com/NYC-Machine-Learning/calendar/11331674/">NYC Machine Learning meetup page</a>. You don&#39;t need to be a machine learning expert to join in the conversation. Just make an honest attempt to read the paper and we can go over questions.</p>
+			</div>
+			
+							<script src="http://feeds.feedburner.com/~s/PaulDixExplainsNothing?i=http%3A%2F%2Fwww.pauldix.net%2F2009%2F09%2Ffirst-nyc-machine-learning-meetup.html" type="text/javascript"></script>
+
+			
+		</div>
+		<div class="entry-footer">
+			<p class="entry-footer-info">
+				<span class="post-footers">September 10, 2009 at 11:22 AM </span> <span class="separator">|</span> <a class="permalink" href="http://www.pauldix.net/2009/09/first-nyc-machine-learning-meetup.html">Permalink</a>
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/09/first-nyc-machine-learning-meetup.html#comments">Comments (0)</a>
+
+				
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/09/first-nyc-machine-learning-meetup.html#trackback">TrackBack (0)</a>
+				
+			</p>
+			<!-- technorati tags -->
+	
+
+
+			<!-- post footer links -->
+
+		</div>
+	</div>
+
+	
+			<h2 class="date-header">July 08, 2009</h2>
+	
+	<div class="entry-author-paul_dix entry-type-post entry" id="entry-6a00d8341f4a0d53ef011571daa51b970b">
+					<h3 class="entry-header"><a href="http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html">Using Named Pipes in Ruby for Inter-process Communication</a></h3>
+		
+		<div class="entry-content">
+			<div class="entry-body">
+				<p>Named pipes are an old trick for Unix types to accomplish communication between processes. I&#39;ve actually never used the trick and it took me a little time to figure out how to do this in ruby. In this post I present a quick example for your enjoyment.</p><p>First, in a terminal window create the named pipe:</p>
+
+<pre>mkfifo my_pipe<br /></pre><p>
+At that point it looks like a file on the file system. It even has permissions on it. Now in Ruby processes we can open it like a file:
+</p><pre>output = open(&quot;my_pipe&quot;, &quot;w+&quot;) # the w+ means we don&#39;t block<br />output.puts &quot;hello world&quot;<br />output.flush # do this when we&#39;re done writing data<br /></pre><p>
+And here we are in a completely separate process:
+</p><pre>input = open(&quot;my_pipe&quot;, &quot;r+&quot;) # the r+ means we don&#39;t block<br />puts input.gets # will block if there&#39;s nothing in the pipe<br /></pre><p>
+
+If you pair that up with JSON, you&#39;ve got a quick and efficient way to do inter-process communication. I&#39;m actually using this trick so I can have my Sinatra web service call out to C++, Java, and Python processes.</p>
+			</div>
+			
+							<script src="http://feeds.feedburner.com/~s/PaulDixExplainsNothing?i=http%3A%2F%2Fwww.pauldix.net%2F2009%2F07%2Fusing-named-pipes-in-ruby-for-interprocess-communication.html" type="text/javascript"></script>
+			
+		</div>
+		<div class="entry-footer">
+			<p class="entry-footer-info">
+				<span class="post-footers">July 08, 2009 at 12:09 PM </span> <span class="separator">|</span> <a class="permalink" href="http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html">Permalink</a>
+
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html#comments">Comments (0)</a>
+				
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html#trackback">TrackBack (0)</a>
+				
+			</p>
+			<!-- technorati tags -->
+	
+
+
+			<!-- post footer links -->
+
+		</div>
+	</div>
+	
+			<h2 class="date-header">June 05, 2009</h2>
+	
+	<div class="entry-author-paul_dix entry-type-post entry" id="entry-67675255">
+					<h3 class="entry-header"><a href="http://www.pauldix.net/2009/06/on-ruby-interview-with-me.html">On Ruby Interview with me</a></h3>
+		
+		<div class="entry-content">
+			<div class="entry-body">
+
+				<p>Pat Eyler of On Ruby has posted <a href="http://on-ruby.blogspot.com/2009/06/feedzirra-and-typhoeus-interview-with.html">an interview with me about Typhoeus, Feedzirra, and software development in general</a>.</p>
+			</div>
+			
+							<script src="http://feeds.feedburner.com/~s/PaulDixExplainsNothing?i=http%3A%2F%2Fwww.pauldix.net%2F2009%2F06%2Fon-ruby-interview-with-me.html" type="text/javascript"></script>
+			
+		</div>
+		<div class="entry-footer">
+			<p class="entry-footer-info">
+				<span class="post-footers">June 05, 2009 at 10:21 AM </span> <span class="separator">|</span> <a class="permalink" href="http://www.pauldix.net/2009/06/on-ruby-interview-with-me.html">Permalink</a>
+
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/06/on-ruby-interview-with-me.html#comments">Comments (0)</a>
+				
+				
+			</p>
+			<!-- technorati tags -->
+	
+
+
+			<!-- post footer links -->
+
+		</div>
+	</div>
+
+	
+			<h2 class="date-header">May 07, 2009</h2>
+	
+	<div class="entry-category-ruby entry-author-paul_dix entry-type-post entry" id="entry-66518947">
+					<h3 class="entry-header"><a href="http://www.pauldix.net/2009/05/breath-fire-over-http-in-ruby-with-typhoeus.html">Breathe fire over HTTP in Ruby with Typhoeus</a></h3>
+		
+		<div class="entry-content">
+			<div class="entry-body">
+				<p>Typhoeus is a mythical greek god with 100 fire breathing serpent heads. He&#39;s also the father of the more well known Hydra. Like the fearsome beast, <a href="http://github.com/pauldix/typhoeus/tree/master">Typhoeus is a fearsome Ruby library that enables parallel HTTP requests while cleanly encapsulating handling logic</a>. Specifically, it uses libcurl and libcurl-multi to run HTTP really fast. Further, it&#39;s designed with the focus of creating client libraries that work with web services. These could be external services like Twitter or systems like CouchDB and SimpleDB or custom web services that you write yourself.
+
+
+</p><p>The libcurl interface is contained within the library. Rather than trying to get Curb to do what I wanted, I decided to start with a clean slate and write the c bindings myself. Other than the libcurl interface, it has a nice DSL for creating classes and client libraries for web services.
+</p><p>The inspiration for the library came from an <a href="http://queue.acm.org/detail.cfm?id=1142065">interview with Amazon CTO Werner Vogels</a>. In the interview he states that when a user visits the Amazon.com home page it calls out to up to 100 different services to construct the single page before returning it to the user. I like Amazon&#39;s approach of a services architecture, specially AWS, and wondered if I could do the same thing in Ruby. Typhoeus is the result of that effort.
+
+</p><p>I set up a benchmark to test how the parallel performance works vs Ruby&#39;s built in NET::HTTP. The setup was a local evented HTTP server that would take a request, sleep for 500 milliseconds and then issued a blank response. I set up the client to call this 20 times. Here are the results:
+
+</p><pre> net::http 0.030000 0.010000 0.040000 ( 10.054327)<br /> typhoeus 0.020000 0.070000 0.090000 ( 0.508817)<br /></pre><p>
+
+We can see from this that NET::HTTP performs as expected, taking 10 seconds to run 20 500ms requests. Typhoeus only takes 500ms (the time of the response that took the longest.)
+</p><p>Hopefully I&#39;ve whetted your appetite. Before I get to the code examples and the API, I&#39;d like to put in a plug for my employer <a href="http://kgb.com">kgb</a>. They were nice enough to let me release this library as open source. We&#39;re also hiring for good front end rails developers, designers, and anyone with experience in search, information retrieval, and machine learning. Please drop me a line if you dominate code and if you&#39;re interested in joining an awesome team.
+
+</p><p>Finally, on the the codez. Here are some usage examples and notes from the readme (<a href="http://gist.github.com/108444">gist for easier reading</a>).
+</p><pre># here&#39;s an example for twitter search<br /># Including Typhoeus adds http methods like get, put, post, and delete.<br /># What&#39;s more interesting though is the stuff to build up what I call<br /># remote_methods.<br />class Twitter<br /> include Typhoeus<br /> remote_defaults :on_success =&gt; lambda {|response| JSON.parse(response.body)},<br /> :on_failure =&gt; lambda {|response| puts &quot;error code: #{response.code}&quot;},<br /> :base_uri =&gt; &quot;http://search.twitter.com&quot;<br /><br /> define_remote_method :search, :path =&gt; &#39;/search.json&#39;<br /> define_remote_method :trends, :path =&gt; &#39;/trends/:time_frame.json&#39;<br />end<br /><br />tweets = Twitter.search(:params =&gt; {:q =&gt; &quot;railsconf&quot;})<br /><br /># if you look at the path argument for the :trends method, it has :time_frame.<br /># this tells it to add in a parameter called :time_frame that gets interpolated<br /># and inserted.<br />trends = Twitter.trends(:time_frame =&gt; :current)<br /><br /># and then the calls don&#39;t actually happen until the first time you<br /># call a method on one of the objects returned from the remote_method<br />puts tweets.keys # it&#39;s a hash from parsed JSON<br /><br /># you can also do things like override any of the default parameters<br />Twitter.search(:params =&gt; {:q =&gt; &quot;hi&quot;}, :on_success =&gt; lambda {|response| puts response.body})<br /><br /># on_success and on_failure lambdas take a response object. <br /># It has four accesssors: code, body, headers, and time<br /><br /># here&#39;s and example of memoization<br />twitter_searches = []<br />10.times do<br /> twitter_searches &lt;&lt; Twitter.search(:params =&gt; {:q =&gt; &quot;railsconf&quot;})<br />end<br /><br /># this next part will actually make the call. However, it only makes one<br /># http request and parses the response once. The rest are memoized.<br />twitter_searches.each {|s| puts s.keys}<br /><br /># you can also have it cache responses and do gets automatically<br /># here we define a remote method that caches the responses for 60 seconds<br />klass = Class.new do<br /> include Typhoeus<br /> <br /> define_remote_method :foo, :base_uri =&gt; &quot;http://localhost:3001&quot;, :cache_responses =&gt; 60<br />end<br /><br />klass.cache = some_memcached_instance_or_whatever<br />response = klass.foo <br />puts response.body # makes the request<br /><br />second_response = klass.foo<br />puts response.body # pulls from the cache without making a request<br /><br /># you can also pass timeouts on the define_remote_method or as a parameter<br /># Note that timeouts are in milliseconds.<br />Twitter.trends(:time_frame =&gt; :current, :timeout =&gt; 2000)<br /><br /># you also get the normal get, put, post, and delete methods<br />class Remote<br /> include Typhoeus<br />end<br /><br />Remote.get(&quot;http://www.pauldix.net&quot;)<br />Remote.put(&quot;http://&quot;, :body =&gt; &quot;this is a request body&quot;)<br />Remote.post(&quot;http://localhost:3001/posts.xml&quot;, <br /> {:params =&gt; {:post =&gt; {:author =&gt; &quot;paul&quot;, :title =&gt; &quot;a title&quot;, :body =&gt; &quot;a body&quot;}}})<br />Remote.delete(&quot;http://localhost:3001/posts/1&quot;)<br /><br /></pre><p><strong>Important Update:</strong>I should have mentioned that some bits of C were pulled from <a href="http://www.idle-hacking.com/2008/07/updated-curb-multi-interface-patch/">Todd Fisher&#39;s update to curb for the multi interface</a>. The easy code is completely different and some of the C stuff in Multi has changed. However, a good chunk of the multi code comes straight from there. Thanks Todd. Sorry for not mentioning it earlier.</p>
+
+			</div>
+			
+							<script src="http://feeds.feedburner.com/~s/PaulDixExplainsNothing?i=http%3A%2F%2Fwww.pauldix.net%2F2009%2F05%2Fbreath-fire-over-http-in-ruby-with-typhoeus.html" type="text/javascript"></script>
+			
+		</div>
+		<div class="entry-footer">
+			<p class="entry-footer-info">
+				<span class="post-footers">May 07, 2009 at 06:52 PM in <a href="http://www.pauldix.net/ruby/">Ruby</a> </span> <span class="separator">|</span> <a class="permalink" href="http://www.pauldix.net/2009/05/breath-fire-over-http-in-ruby-with-typhoeus.html">Permalink</a>
+
+									<span class="separator">|</span>
+					<a href="http://www.pauldix.net/2009/05/breath-fire-over-http-in-ruby-with-typhoeus.html#comments">Comments (18)</a>
+				
+				
+			</p>
+			<!-- technorati tags -->
+	
+
+
+			<!-- post footer links -->
+
+		</div>
+	</div>
+
+			<div class="pager-bottom pager-entries pager content-nav">
+		<div class="pager-inner">
+			
+			
+			<span class="pager-right">
+				<a href="http://www.pauldix.net/page/2/"><span class="pager-label"></span>
+					<span class="chevron">&#187;</span></a>
+			</span>
+		</div>
+	</div>
+	
+	
+
+
+						</div>
+
+					</div>
+					<div id="beta">
+						<div id="beta-inner" class="pkg">
+							<!-- sidebar -->
+
+
+<!-- user photo -->
+	<div class="module-photo module">
+		<div class="module-content"><img src="http://pauldix.blogs.com/.a/6a00d8341f4a0d53ef00e553f5dd328833-150wi" alt="My Photo" /></div>
+	</div>
+
+<div class="module-widget module" id="widget-LinkedIn_linkedin_profile_widget">
+	<div class="module-content">
+    	            <div style="text-align:center"><a href="http://www.linkedin.com/in/pauldix?trk=btn_typepad" ><img src="http://www.linkedin.com/img/webpromo/btn_viewmy_160x25.gif" width="160" height="25" border="0" alt="View Paul Dix's profile on LinkedIn" style="margin-bottom:5px"></a><br><a href="http://www.linkedin.com/in/pauldix?trk=btn_typepad" style="color:#0783B6;font:11px arial,sans-serif;text-decoration:none">See how we're connected</a></div>
+          
+	</div>
+</div><div class="module-email module">
+	<div class="module-content">
+		<script type="text/javascript">
+<!--
+document.write('<a href="ma' + 'ilto:&#112;&#97;&#117;&#108;&#64;&#112;&#97;&#117;&#108;&#100;&#105;&#120;&#46;&#110;&#101;&#116;">Email Me</a>');
+// -->
+</script>
+
+	</div>
+
+</div>
+<div class="module-widget module" id="widget-FeedBurner_standardSmall">
+	<div class="module-content">
+    	<p><a href="http://feeds.feedburner.com/PaulDixExplainsNothing" rel="alternate" type="application/rss+xml"><img src="http://www.feedburner.com/fb/images/pub/feed-icon16x16.png" alt="" style="vertical-align:middle;border:0"/></a>&nbsp;<a href="http://feeds.feedburner.com/PaulDixExplainsNothing/in_body/rss" rel="alternate" type="application/rss+xml">Subscribe in a reader</a> <a href="http://feeds.feedburner.com/PaulDixExplainsNothing/in_body/atom" rel="alternate" type="application/atom+xml">Subscribe in a reader</a></p>
+	</div>
+</div><div class="module-typelist module">
+	<h2 class="module-header">Linkage</h2>
+	<div class="module-content">
+		<ul class="module-list">
+
+							<li class="module-list-item"><a href="http://github.com/pauldix">My Github</a><br /></li>
+							<li class="module-list-item"><a href="http://github.com/pauldix/feedzirra">Feedzirra</a><br />My Ruby library for parsing and fetching feeds at blinding speed.</li>
+							<li class="module-list-item"><a href="http://github.com/pauldix/sax-machine">SAX Machine</a><br />My Ruby library exposes a DSL for building Nokogiri backed SAX parsers.</li>
+							<li class="module-list-item"><a href="http://github.com/pauldix/typhoeus">Typhoeus</a><br />My Ruby library for running HTTP requests quickly, easily, and in parallel.</li>
+			
+		</ul>
+
+	</div>
+</div>
+
+	<div class="module-archives module">
+		<h2 class="module-header">Recent Posts</h2>
+		<div class="module-content">
+			<ul class="module-list">
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/10/using-the-nginx-memcached-module-with-passenger.html">Using the Nginx Memcached module with Passenger</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/09/first-nyc-machine-learning-meetup.html">First NYC Machine Learning Meetup</a></li>
+
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/07/using-named-pipes-in-ruby-for-interprocess-communication.html">Using Named Pipes in Ruby for Inter-process Communication</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/06/on-ruby-interview-with-me.html">On Ruby Interview with me</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/05/breath-fire-over-http-in-ruby-with-typhoeus.html">Breathe fire over HTTP in Ruby with Typhoeus</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/05/railsconf-this-week.html">RailsConf this week</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/04/small-feedzirra-release.html">Small Feedzirra Release</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/04/notes-from-my-machine-learning-and-the-semantic-web-presentation.html">Notes from my Machine Learning and the Semantic Web Presentation</a></li>
+
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/04/a-passenger-rackup-file-for-sinatra.html">A Passenger Rackup File for Sinatra</a></li>
+					
+														<li class="module-list-item"><a href="http://www.pauldix.net/2009/03/feedzirra-release-adds-simple-custom-parsing-and-more.html">Feedzirra release adds simple custom parsing and more!</a></li>
+					
+				
+			</ul>
+		</div>
+	</div>
+<div class="module-feed module">
+	<h2 class="module-header">Twitter / pauldix</h2>
+	<div class="module-content" id="feed-39393fef12adc57def656d605a14747caac52903">
+
+		<script type="text/javascript" defer="defer" src="http://pauldix.blogs.com/.services/content?src=Feed:http%3A%2F%2Ftwitter.com%2Fstatuses%2Fuser_timeline%2F13826102.rss,5"></script>
+	</div>
+</div>
+<div class="module-elsewhere module">
+	<h2 class="module-header">Services I'm On</h2>
+			<div class="typelist-plain module-content">
+			<ul class="module-list">
+									<li class="module-list-item">
+						<a href="aim:goim?screenname=dixp77"><img src="/.shared/images/profile/service_icons/aim.png" alt="AIM" width="16" height="16" /></a>
+
+						<a href="aim:goim?screenname=dixp77" rel="me">AIM: dixp77</a>
+					</li>
+									<li class="module-list-item">
+						<a href="http://delicious.com/pauldix"><img src="/.shared/images/profile/service_icons/delicious.png" alt="Delicious" width="16" height="16" /></a>
+						<a href="http://delicious.com/pauldix" rel="me">Delicious: pauldix</a>
+					</li>
+									<li class="module-list-item">
+						<a href="http://www.facebook.com/profile.php?id=pcd2104%40columbia.edu"><img src="/.shared/images/profile/service_icons/facebook.png" alt="Facebook" width="16" height="16" /></a>
+
+						<a href="http://www.facebook.com/profile.php?id=pcd2104%40columbia.edu" rel="me">Facebook: pcd2104@columbia.edu</a>
+					</li>
+									<li class="module-list-item">
+						<a href="http://www.flickr.com/photos/pauldix/"><img src="/.shared/images/profile/service_icons/flickr.png" alt="Flickr" width="16" height="16" /></a>
+						<a href="http://www.flickr.com/photos/pauldix/" rel="me">Flickr: pauldix</a>
+					</li>
+									<li class="module-list-item">
+						<a href="msnim:chat?contact=paul%40pauldix.net"><img src="/.shared/images/profile/service_icons/msn.png" alt="MSN Messenger" width="16" height="16" /></a>
+
+						<a href="msnim:chat?contact=paul%40pauldix.net" rel="me">MSN Messenger: paul@pauldix.net</a>
+					</li>
+									<li class="module-list-item">
+						<a href="callto://paulcdix"><img src="/.shared/images/profile/service_icons/skype.png" alt="Skype" width="16" height="16" /></a>
+						<a href="callto://paulcdix" rel="me">Skype: paulcdix</a>
+					</li>
+									<li class="module-list-item">
+						<a href="http://twitter.com/pauldix"><img src="/.shared/images/profile/service_icons/twitter.png" alt="Twitter" width="16" height="16" /></a>
+
+						<a href="http://twitter.com/pauldix" rel="me">Twitter: pauldix</a>
+					</li>
+									<li class="module-list-item">
+						<a href="http://edit.yahoo.com/config/send_webmesg?.target=paulcdix"><img src="/.shared/images/profile/service_icons/yahoo.png" alt="Yahoo!" width="16" height="16" /></a>
+						<a href="http://edit.yahoo.com/config/send_webmesg?.target=paulcdix" rel="me">Yahoo!: paulcdix</a>
+					</li>
+				
+			</ul>
+		</div>
+
+	
+	
+</div>
+	<div class="module-archives module">
+		<h2 class="module-header"><a href="http://www.pauldix.net/archives.html">Archives</a></h2>
+		<div class="module-content">
+												<ul class="module-list">
+				
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/10/index.html">October 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/09/index.html">September 2009</a></li>
+
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/07/index.html">July 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/06/index.html">June 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/05/index.html">May 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/04/index.html">April 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/03/index.html">March 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/02/index.html">February 2009</a></li>
+
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2009/01/index.html">January 2009</a></li>
+				
+							
+				<li class="module-list-item"><a href="http://www.pauldix.net/2008/12/index.html">December 2008</a></li>
+									</ul>
+									<p class="module-more"><a href="http://www.pauldix.net/archives.html">More...</a></p>
+				
+				
+			
+		</div>
+	</div>
+
+<div class="module-widget module" id="widget-Widgetbox_1f1dca67-0b36-4e14-803b-6bfd184abac1">
+
+	<div class="module-content">
+    	<script type="text/javascript" src="http://widgetserver.com/syndication/subscriber/InsertPanel.js?panelId=1f1dca67-0b36-4e14-803b-6bfd184abac1"></script>
+	</div>
+</div>
+
+
+
+						</div>
+					</div>
+				</div>
+
+			</div>
+			
+
+		</div>
+	</div>
+	
+
+<script type="text/javascript">
+<!--
+var extra_happy = Math.floor(1000000000 * Math.random());
+document.write('<img src="http://www.typepad.com/t/stats?blog_id=108605&amp;user_id=280961&amp;page=' + escape(location.href) + '&amp;referrer=' + escape(document.referrer) + '&amp;i=' + extra_happy + '" width="1" height="1" alt="" style="position: absolute; top: 0; left: 0;" />');
+// -->
+</script>
+
+
+<!-- Start Quantcast tag -->
+<script type="text/javascript" src="http://edge.quantserve.com/quant.js"></script>
+<script type="text/javascript">_qoptions = { tags:"typepad.extended" }; _qacct="p-fcYWUmj5YbYKM"; quantserve();</script>
+<noscript>
+<a href="http://www.quantcast.com/p-fcYWUmj5YbYKM" target="_blank"><img src="http://pixel.quantserve.com/pixel/p-fcYWUmj5YbYKM.gif?tags=typepad.extended" style="display: none" border="0" height="1" width="1" alt="Quantcast"/></a>
+
+</noscript>
+<!-- End Quantcast tag -->
+
+<script src="http://cdn.media6degrees.com/static/ty2093.js" type="text/javascript"></script></body>
+</html>
+<!-- ph=1 -->
+<!-- nhm:from_kauri -->


### PR DESCRIPTION
This commit adds the ability to parse feed urls regardless of the case of the tag, attributes, or scheme in absolute urls and allows attributes of a tag to be matched across whitespace.

These changes are independent of my previous pull request so that you can merge everything however you like. I have an "all_fixes" branch in which I've merged all this together for my own use, if you'd rather use that instead.
